### PR TITLE
adds  airflow_password retrieval script and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ If you want to run commands in the "Airflow context" (_i.e._ within the custom c
 # Run an Airflow CLI command
 ./airflow.sh info
 ```
+
+## Logging into Airflow
+
+When deployed in AWS EC2, the username for admin login will be "dpe" rather than the default "airflow". The password is securely stored in AWS Secret Manager and the DPE LastPass vault. If you have access to the `org-sagebase-dpe-prod` AWS account, you can authenticate your connection to AWS in your terminal using `aws sso login` and then run `bash airflow_password.sh` in your terminal, the password will print in your terminal. 

--- a/airflow_password.sh
+++ b/airflow_password.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+airflow_password=$(aws --output text secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1)
+echo $airflow_password

--- a/airflow_password.sh
+++ b/airflow_password.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-airflow_password=$(aws --output text secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1)
-echo $airflow_password
+aws --output text secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1


### PR DESCRIPTION
This PR adds a bash script used to retrieve the production airflow password from AWS secret manager. This way, when airflow is deployed, this script can be used in the CloudFormation template to retrieve the password and configure the admin account along with the added bonus of allowing users and developers to retrieve the password themselves and use it to log in. CC @BrunoGrandePhD 