### PR TITLE
[ORCA-143] Add Tom to Tower Metrics Report

### DIFF
--- a/dags/dag_content/tower_metrics_content.py
+++ b/dags/dag_content/tower_metrics_content.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import synapseclient
 from airflow.decorators import task
-from airflow.operators.python import get_current_context
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.hooks.secrets_manager import SecretsManagerHook

--- a/dags/dag_content/tower_metrics_content.py
+++ b/dags/dag_content/tower_metrics_content.py
@@ -105,25 +105,34 @@ def package_query_data(response: dict) -> list[dict[str, Any]]:
 
 
 # creates RDS boto3 hook inside task
-def create_rds_connection(aws_conn_id: str = AWS_CONN_ID, region_name: str = AWS_REGION):
+def create_rds_connection(
+    aws_conn_id: str = AWS_CONN_ID, region_name: str = AWS_REGION
+):
     rds_hook = RdsHook(aws_conn_id=aws_conn_id, region_name=region_name)
     rds_client = rds_hook.get_conn()
     return rds_hook, rds_client
 
 
 # creates RDS Data boto3 hook inside task
-def create_rds_data_connection(aws_conn_id: str = AWS_CONN_ID, client_type:str = "rds-data", region_name: str = AWS_REGION):
-    rds_data_hook = AwsBaseHook(aws_conn_id=aws_conn_id, client_type=client_type, region_name=region_name)
+def create_rds_data_connection(
+    aws_conn_id: str = AWS_CONN_ID,
+    client_type: str = "rds-data",
+    region_name: str = AWS_REGION,
+):
+    rds_data_hook = AwsBaseHook(
+        aws_conn_id=aws_conn_id, client_type=client_type, region_name=region_name
+    )
     rds_data_client = rds_data_hook.get_conn()
     return rds_data_hook, rds_data_client
 
 
 # creates Secrets Manager boto3 hook inside task
-def create_secrets_manager_connection(aws_conn_id: str = AWS_CONN_ID, region_name: str = AWS_REGION):
+def create_secrets_manager_connection(
+    aws_conn_id: str = AWS_CONN_ID, region_name: str = AWS_REGION
+):
     secrets_hook = SecretsManagerHook(aws_conn_id=aws_conn_id, region_name=region_name)
     secrets_client = secrets_hook.get_conn()
     return secrets_hook, secrets_client
-
 
 
 # TASKS
@@ -251,9 +260,7 @@ def modify_database_clone(clone_name: str, password: str):
 
 
 @task
-def update_secret(
-    clone_name: str, db_info: dict, password: str
-) -> str:
+def update_secret(clone_name: str, db_info: dict, password: str) -> str:
     """
     updates secret in secret manager with formatted string includung new database info and random password
 
@@ -281,7 +288,9 @@ def update_secret(
         SecretId="Programmatic-DB-Clone-Access", SecretString=secret_string
     )
     secret_arn = response["ARN"]
-    time.sleep(30) #query_database always fails the first time because secret modification isnt done yet
+    time.sleep(
+        30
+    )  # query_database always fails the first time because secret modification isnt done yet
     return secret_arn
 
 
@@ -333,8 +342,11 @@ def delete_clone_database(clone_name: str):
         SkipFinalSnapshot=True,
     )
     time.sleep(20)  # allow process time to start before starting waiter
-    waiter = rds_client.get_waiter("db_cluster_deleted") #no provider waiter for this status
+    waiter = rds_client.get_waiter(
+        "db_cluster_deleted"
+    )  # no provider waiter for this status
     waiter.wait(DBClusterIdentifier=clone_name)
+
 
 @task
 def export_json_to_synapse(json_list: list):
@@ -354,15 +366,13 @@ def export_json_to_synapse(json_list: list):
 
 
 @task
-def send_synapse_notification():
+def send_synapse_notification(user_list: list):
     """
     sends email notification to synapse users in user_list that report has been uploaded
+
+    Args:
+        user_list(list): list of Synapse usernames to send report notification message to.
     """
-    user_list = [
-        "bwmac",  # Brad
-        # "thomas.yu", # Tom
-        # "bgrande", # Bruno
-    ]
 
     syn = create_synapse_session()
 

--- a/dags/dag_content/tower_metrics_content.py
+++ b/dags/dag_content/tower_metrics_content.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import synapseclient
 from airflow.decorators import task
+from airflow.operators.python import get_current_context
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.hooks.secrets_manager import SecretsManagerHook
@@ -366,18 +367,16 @@ def export_json_to_synapse(json_list: list):
 
 
 @task
-def send_synapse_notification(user_list: list):
+def send_synapse_notification():
     """
-    sends email notification to synapse users in user_list that report has been uploaded
-
-    Args:
-        user_list(list): list of Synapse usernames to send report notification message to.
+    sends email notification to synapse users in user_list that report has been uploaded.
+    requires a parameter passed to the dag with the id "user_list"
     """
 
     syn = create_synapse_session()
 
     id_list = []
-    for user in user_list:
+    for user in get_current_context()["params"]["user_list"]:
         id_list.append(syn.getUserProfile(user).get("ownerId"))
 
     syn.sendMessage(

--- a/dags/dag_content/tower_metrics_content.py
+++ b/dags/dag_content/tower_metrics_content.py
@@ -368,7 +368,7 @@ def export_json_to_synapse(json_list: list):
 @task
 def send_synapse_notification(**context):
     """
-    sends email notification to synapse users in user_list that report has been uploaded
+    sends email notification to Synapse users in Airflow param 'user_list' that report has been uploaded
     """
     user_list = context["params"]["user_list"].split(",")
 

--- a/dags/dag_content/tower_metrics_content.py
+++ b/dags/dag_content/tower_metrics_content.py
@@ -367,17 +367,15 @@ def export_json_to_synapse(json_list: list):
 
 
 @task
-def send_synapse_notification():
+def send_synapse_notification(**context):
     """
-    sends email notification to synapse users in user_list that report has been uploaded.
-    requires a parameter passed to the dag with the id "user_list"
+    sends email notification to synapse users in user_list that report has been uploaded
     """
+    user_list = context["params"]["user_list"].split(",")
 
     syn = create_synapse_session()
 
-    id_list = []
-    for user in get_current_context()["params"]["user_list"]:
-        id_list.append(syn.getUserProfile(user).get("ownerId"))
+    id_list = [syn.getUserProfile(user).get("ownerId") for user in user_list]
 
     syn.sendMessage(
         id_list,

--- a/dags/tower_metrics_dag.py
+++ b/dags/tower_metrics_dag.py
@@ -46,13 +46,13 @@ def tower_metrics_dag():
     # delete cloned database - wait for it to be gone before completing process
     delete = delete_clone_database(clone_name=CLONE_DATABASE_NAME)
 
-
-    #add missing dependencies
+    # add missing dependencies
     prod_db_info >> clone_db_info
     [clone_db_info, password] >> modify
     [clone_db_info, password] >> secret_arn
     [secret_arn, modify] >> json_list
     json_list >> [export, delete]
     export >> send
+
 
 tower_metrics_dag = tower_metrics_dag()

--- a/dags/tower_metrics_dag.py
+++ b/dags/tower_metrics_dag.py
@@ -14,7 +14,7 @@ dag_params = {
 
 
 @dag(
-    schedule_interval="0 15 * * 5",  # Fridays at 3PM PST
+    schedule_interval="0 23 * * 5",  # Fridays at 3PM PST
     start_date=datetime(2022, 11, 11),
     catchup=False,
     default_args={

--- a/dags/tower_metrics_dag.py
+++ b/dags/tower_metrics_dag.py
@@ -1,20 +1,25 @@
 from datetime import datetime
 
 from airflow.decorators import dag
-
+from airflow.models.param import Param
 from dag_content.tower_metrics_content import *
+
+dag_params = {
+    "user_list": Param(["bwmac", "thomas.yu"], type="list"),
+}
 
 
 @dag(
-    schedule_interval="@weekly",
+    schedule_interval="0 15 * * 5",  # Fridays 3PM PST
     start_date=datetime(2022, 11, 11),
     catchup=False,
     default_args={
         "retries": 3,
     },
     tags=["Nextflow Tower Metrics"],
+    params=dag_params,
 )
-def tower_metrics_dag():
+def tower_metrics_dag(**context):
     # get needed info from production database for cloining
     prod_db_info = get_database_info(db_name=DATABASE_NAME)
     # clone tower database

--- a/dags/tower_metrics_dag.py
+++ b/dags/tower_metrics_dag.py
@@ -2,15 +2,19 @@ from datetime import datetime
 
 from airflow.decorators import dag
 from airflow.models.param import Param
+
 from dag_content.tower_metrics_content import *
 
 dag_params = {
-    "user_list": Param(["bwmac", "thomas.yu"], type="list"),
+    "user_list": Param(
+        "bwmac,thomas.yu",  # no support for python lists
+        type="string",
+    )
 }
 
 
 @dag(
-    schedule_interval="0 15 * * 5",  # Fridays 3PM PST
+    schedule_interval="0 15 * * 5",  # Fridays at 3PM PST
     start_date=datetime(2022, 11, 11),
     catchup=False,
     default_args={
@@ -19,7 +23,7 @@ dag_params = {
     tags=["Nextflow Tower Metrics"],
     params=dag_params,
 )
-def tower_metrics_dag(**context):
+def tower_metrics_dag():
     # get needed info from production database for cloining
     prod_db_info = get_database_info(db_name=DATABASE_NAME)
     # clone tower database


### PR DESCRIPTION
This PR adds functionality for the list of synapse users that are sent the tower metrics dag report to be parameterized and adds Tom to the list of users that receive the report. Because there is apparently no support for python lists in airflow `Param`, the list is provided as a comma-separated string which is converted to a list when the usernames are needed in the `send_synapse_notification` task. I have also changed the schedule on this DAG to run every Friday at 3PM PST, let me know if there is a time or cadence that you would prefer instead @thomasyu888.

This change has been successfully tested on the `dnt-dev` airflow instance.