### PR TITLE
[ORCA-146] Configure docker compose stack to pass through AWS credentials

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,5 +40,10 @@
     // "customizations": {},
 
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    "remoteUser": "vscode"
+    "remoteUser": "vscode",
+
+    // Ensure enough memory for multi-container Airflow stack
+    "hostRequirements": {
+        "memory": "8gb"
+    }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ There is a helper script in this repository for accessing these Airflow servers.
 
 To develop on this repository, it's recommended that you use the Dev Containers setup online using GitHub Codespaces. While the entry-level machine type (2-core, 4GB RAM) in Codespaces supports basic editing, you should use a bigger machine type (at least 4-core, 8GB RAM) if you plan on running Airflow using Docker Compose.
 
+Note that you don't need to add your AWS credentials to the `.env` file when using GitHub Codespaces because a default IAM user has been configured in the repository's secrets.
+
 ## Secrets
 
 Airflow secrets (_e.g._ connections and variables) are stored in the following locations:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ cp .env.example .env
 docker compose up --build --detach
 ```
 
+If you encounter the `nginx bad gateway` errors when navigating to the forwarded port, just wait and refresh a couple of times. Airflow takes a few minutes to become available.
+
 Any edits to your DAG should get picked up by Airflow automatically. If you're not seeing that happen, you can try restarting the containers as follows.
 
 ```console
@@ -43,3 +45,4 @@ If you want to run commands in the "Airflow context" (_i.e._ within the custom c
 ## Logging into Airflow
 
 When deployed in AWS EC2, the username for admin login will be "dpe" rather than the default "airflow". The password is securely stored in AWS Secret Manager and the DPE LastPass vault. If you have access to the `org-sagebase-dpe-prod` AWS account, you can authenticate your connection to AWS in your terminal using `aws sso login` and then run `bash airflow_password.sh` in your terminal, the password will print in your terminal. 
+

--- a/dags/test_secrets.py
+++ b/dags/test_secrets.py
@@ -1,0 +1,32 @@
+import os
+from datetime import datetime
+from typing import Any
+
+from airflow.decorators import dag, task
+from orca.services.sevenbridges import SevenBridgesHook
+
+dag_args: dict[str, Any]
+dag_args = {
+    "schedule": None,
+    "start_date": datetime(2023, 1, 1),
+    "catchup": False,
+}
+
+
+@dag(**dag_args)
+def test_secrets():
+    @task
+    def check_task():
+        hook = SevenBridgesHook("cavatica_test")
+        hook.ops.get_task_status("4c258aba-8d62-4912-8746-631d76af5b25")
+
+    @task
+    def print_env():
+        print(os.environ)
+
+    status = check_task()
+    env = print_env()
+    env >> status
+
+
+test_secrets()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,10 @@ x-airflow-common:
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth'
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+    # Passing through AWS credentials
+    AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+    AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+    AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
   volumes:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs


### PR DESCRIPTION
In order to leverage GitHub Codespaces, we need to provide Airflow with access to the connection credentials in AWS Secrets Manager. I wasn't able to get this to work when I first tested Codespaces. I realized that the AWS credentials being set in environment variables weren't being picked up by the Secrets Manager backend in Airflow unless they were provided in the `.env` file. That's when I realized that the docker compose stack needs to explicitly pass through environment variables. Since then, I'm able to access secrets from AWS in Codespaces! 

![image](https://user-images.githubusercontent.com/740725/229969364-c1ade3a1-3474-4c43-967a-a5da8a21c167.png)
