### PR TITLE
[GEN-782] Fix genie validation dag

### DIFF
--- a/dags/genie-nf-validate.py
+++ b/dags/genie-nf-validate.py
@@ -13,8 +13,7 @@ dag_params = {
     "pipeline": Param("Sage-Bionetworks-Workflows/nf-genie", type="string"),
     "revision": Param("main", type="string"),
     "profile": Param("aws_prod", type="string"),
-    "only_validate": Param("true", type="string"),
-    "production": Param("true", type="string"),
+    "process_type": Param("only_validate", type="string"),
     "release": Param("13.3-consortium", type="string"),
     "work_dir": Param("s3://genie-bpc-project-tower-scratch/1days", type="string"),
 }
@@ -49,11 +48,10 @@ def genie_nf_validate_dag():
             work_dir=context["params"]["work_dir"],
             profiles=[context["params"]["profile"]],
             workspace_secrets=["SYNAPSE_AUTH_TOKEN"],
-            params_yaml=f"""
-                only_validate: {context["params"]["only_validate"]}
-                production: {context["params"]["production"]}
-                release: {context["params"]["release"]}
-                """,
+            params={
+                "process_type": context["params"]["process_type"],
+                "release": context["params"]["release"]
+            },
         )
         run_id = hook.ops.launch_workflow(
             info, context["params"]["tower_compute_env_type"], ignore_previous_runs=True

--- a/dags/genie-nf-validate.py
+++ b/dags/genie-nf-validate.py
@@ -8,7 +8,7 @@ from orca.services.nextflowtower.models import LaunchInfo
 
 dag_params = {
     "tower_conn_id": Param("GENIE_BPC_PROJECT_TOWER_CONN", type="string"),
-    "tower_compute_env_type": Param("spot", type="string"),
+    "tower_compute_env_type": Param("ondemand", type="string"),
     "tower_run_name": Param("airflow-genie-validate", type="string"),
     "pipeline": Param("Sage-Bionetworks-Workflows/nf-genie", type="string"),
     "revision": Param("main", type="string"),


### PR DESCRIPTION
**Purpose:** This fixes the genie DAG so the parameters passed through the DAG are getting propagated through to the Nextflow workflow call. Previously, I believe it was because the `params_yaml` doesn't exist in the [LaunchInfo's specification](https://github.com/Sage-Bionetworks-Workflows/py-orca/blob/main/src/orca/services/nextflowtower/models.py#L153-L169), and only `params` does, the Nextflow workflow behavior in light of not receiving the defined params from Airflow would default to the default param values in the main genie nextflow pipeline.

Did test runs in the local Airflow UI, and the latest nextflow tower run reflects the param values passed from Airflow correctly:
<img width="355" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/orca-recipes-airflow/assets/26471741/0e2069fb-8940-40af-91e1-4d5547eb1475">


Also the [params for nf-genie](https://github.com/Sage-Bionetworks-Workflows/nf-genie/blob/main/nextflow_schema.json#L14-L24) had been updated, so this DAG has been updated to reflect that.