### PR TITLE
[ORCA-267] Updates Documentation for secrets backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,10 @@ Testing should be done via the Dev Containers setup online using GitHub Codespac
 
 ## Secrets
 
-Airflow secrets (_e.g._ connections and variables) are stored in the following locations:
+Airflow secrets (_e.g._ connections and variables) are stored in the `dpe-prod` AWS account.
 
-<!-- Maybe we can store all secrets (both test and prod) in `dpe-prod`? -->
-- `dpe-prod` AWS account: Production-level secrets (_e.g._ actual Tower workspaces)
-- `dnt-dev` AWS account: Test-level secrets (_e.g._ `example-project` Tower workspace)
+The credentials for the `dpe-prod` AWS service account are stored in the `orca-recipes` repository, enabling the AWS Secrets Manager backend to retrieve values from `dpe-prod`.
 
-The credentials for a `dnt-dev` AWS service account will be stored in the `orca-recipes-airflow` repository, enabling the AWS Secrets Manager backend to retrieve values from `dnt-dev`.
+New secrets only need to be created in the `dpe-prod` account. For connection URIs, the secret name should have the prefix `airflow/connections`. Variables should have the prefix `airflow/variables`.
 
-New secrets will need to be created in both AWS accounts. You can start with the `dnt-dev` account with test credentials. Once the DAG is ready for production, the actual credentials will get stored in `dpe-prod`.
+During DAG development and testing, you can create a secret containing the connection URI (or secret variable) for development resources (such as Nextflow Tower Dev). Once you are ready to run the DAG in production, you can update the secret value with a connection URI for production resources (such as Nextflow Tower Prod).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# ORCA Airflow Recipes
+# ORCA Recipes
 
-This repository contains Airflow recipes (DAGs) for data processing and engineering at Sage Bionetworks.
+This repository contains recipes (DAGs) for data processing and engineering at Sage Bionetworks.
 
-## Quick Start
+## Airflow
+
+### Quick Start
 
 This assumes that you have Docker installed with [Docker Compose V2](https://docs.docker.com/compose/compose-v2/). It's recommended that you leverage the included Dev Container definition (_i.e._ `devcontainer.json`) to standardize your development environment. You can use the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) VS Code extension or GitHub Codespaces.
 
@@ -42,6 +44,19 @@ If you want to run commands in the "Airflow context" (_i.e._ within the custom c
 ./airflow.sh info
 ```
 
-## Logging into Airflow
+### Logging in
 
 When deploying airflow locally on dev containers, the username and password will be "airflow".
+
+## Local DAGs
+
+### Usage
+
+This repository also contains recipes for specific projects that either don't need to be deployed to Airflow or are not ready to be deployed to Airflow. These recipes can be run locally from the `local` directory. Each sub-directory contains recipes specific to a project and those project folders have their own documentation for running the recipes.
+
+### Dependencies
+
+Dependencies for `local` recipes are defined in the `Pipfile` at the root of this repository. To get started, you can install all of the dependencies that you might need by running:
+```console
+pipenv install --dev
+```


### PR DESCRIPTION
This PR updates the documentation for the `orca-recipes` repository to reflect the updated secrets backend management. 

I also updated  `README.md` to include some basic information about the `local` project-specific DAGs which we recently added to the repository.