### PR TITLE
[ORCA-273] Adds `nf-dynamic-challenge` Nextflow Tower DAG

### DIFF
--- a/dags/nf-dynamic-challenge-dag.py
+++ b/dags/nf-dynamic-challenge-dag.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task
+from airflow.models import Param
+
+from orca.services.nextflowtower import NextflowTowerHook
+from orca.services.nextflowtower.models import LaunchInfo
+
+
+dag_params = {
+    "tower_conn_id": Param("EXAMPLE_DEV_PROJECT_TOWER_CONN", type="string"),
+    "tower_run_name": Param("nf-dynamic-challenge-test", type="string"),
+    "tower_compute_env_type": Param("spot", type="string"),
+}
+
+dag_config = {
+    "schedule_interval": None,
+    "start_date": datetime(2023, 6, 1),
+    "catchup": False,
+    "default_args": {
+        "retries": 2,
+    },
+    "tags": ["nextflow_tower"],
+    "params": dag_params,
+}
+
+
+@dag(**dag_config)
+def nf_dynamic_challenge_dag():
+    @task()
+    def launch_nf_dynamic_challenge_on_tower(**context):
+        hook = NextflowTowerHook(context["params"]["tower_conn_id"])
+        info = LaunchInfo(
+            run_name=context["params"]["tower_run_name"],
+            pipeline="Sage-Bionetworks-Workflows/nf-dynamic-challenge",
+            revision=" bwmac/orca-273/update_workflow_inputs",
+        )
+        run_id = hook.ops.launch_workflow(
+            info, context["params"]["tower_compute_env_type"]
+        )
+        return run_id
+
+    @task.sensor(poke_interval=300, timeout=604800, mode="reschedule")
+    def monitor_nf_hello_workflow(run_id: str, **context):
+        hook = NextflowTowerHook(context["params"]["tower_conn_id"])
+        workflow = hook.ops.get_workflow(run_id)
+        print(f"Current workflow state: {workflow.status.state.value}")
+        return workflow.status.is_done
+
+    run_id = launch_nf_dynamic_challenge_on_tower()
+    monitor_nf_hello_workflow(run_id=run_id)
+
+
+nf_dynamic_challenge_dag()

--- a/dags/nf-dynamic-challenge-dag.py
+++ b/dags/nf-dynamic-challenge-dag.py
@@ -8,9 +8,12 @@ from orca.services.nextflowtower.models import LaunchInfo
 
 
 dag_params = {
-    "tower_conn_id": Param("EXAMPLE_DEV_PROJECT_TOWER_CONN", type="string"),
+    "tower_conn_id": Param("DYNAMIC_CHALLENGE_PROJECT_TOWER_CONN", type="string"),
     "tower_run_name": Param("nf-dynamic-challenge-test", type="string"),
     "tower_compute_env_type": Param("spot", type="string"),
+    "challenge_view_id": Param("syn52576179", type="string"),
+    "tower_cpus": Param("4", type="string"),
+    "tower_memory": Param("16.GB", type="string"),
 }
 
 dag_config = {
@@ -33,7 +36,11 @@ def nf_dynamic_challenge_dag():
         info = LaunchInfo(
             run_name=context["params"]["tower_run_name"],
             pipeline="Sage-Bionetworks-Workflows/nf-dynamic-challenge",
-            revision=" bwmac/orca-273/update_workflow_inputs",
+            revision="main",
+            params={
+                "view_id": context["params"]["challenge_view_id"],
+            },
+            workspace_secrets=["SYNAPSE_AUTH_TOKEN"],
         )
         run_id = hook.ops.launch_workflow(
             info, context["params"]["tower_compute_env_type"]


### PR DESCRIPTION
This PR contributes `nf-dynamic-challenge-dag.py` which follows a similar structure to other Nextflow Tower DAGs in the repo.

This new DAG does the following:
- Takes parameters defined by the `nf-dynamic-challenge` workflow (`view_id`, `cpus`, and `memory`)
- Connects to the production instance of Nextflow Tower (`dynamic-challenge-project`)
- Launches `nf-dynamic-challenge` using an example [file view](https://www.synapse.org/#!Synapse:syn52576179/tables/) I created for testing
- Monitors the workflow until its completion

This DAG has been tested in GitHub Codespaces and the Nextflow Workflow completed successfully in Tower.
