### PR TITLE
[ORCA-296] pegs challenge DAG

### DIFF
--- a/dags/pegs-challenge-submission-dag.py
+++ b/dags/pegs-challenge-submission-dag.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task
+from airflow.models import Param
+
+from orca.services.nextflowtower import NextflowTowerHook
+from orca.services.nextflowtower.models import LaunchInfo
+from orca.services.synapse import SynapseHook
+
+
+dag_params = {
+    "synapse_conn_id": Param("SYNAPSE_CHALLENGE_CONN", type="string"),
+    "synapse_evaluation_id": Param("9615511", type="string"),
+    "tower_conn_id": Param("PEGS_CHALLENGE_PROJECT_TOWER_CONN", type="string"),
+    "tower_run_name": Param("pegs_model_submission_evaluation", type="string"),
+    "tower_view_id": Param("syn53239158", type="string"),
+    "tower_input_id": Param("syn53239289", type="string"),
+    "tower_compute_env_type": Param("spot", type="string"),
+}
+
+dag_config = {
+    "schedule_interval": None,
+    "start_date": datetime(2023, 6, 1),
+    "catchup": False,
+    "default_args": {
+        "retries": 2,
+    },
+    "tags": ["nextflow_tower"],
+    "params": dag_params,
+}
+
+
+@dag(**dag_config)
+def pegs_challenge_submission_dag():
+    @task.branch()
+    def check_for_new_submissions(**context):
+        """
+        Checks for new submissions
+
+        Args:
+            evaluation_id (str): Evaluation ID for challenge
+        """
+        hook = SynapseHook(context["params"]["synapse_conn_id"])
+        if hook.ops.monitor_evaluation_queue(
+            context["params"]["synapse_evaluation_id"]
+        ):
+            return "launch_model2data_workflow"
+        return "stop_dag"
+
+    @task()
+    def stop_dag():
+        pass
+
+    @task()
+    def launch_model2data_workflow(**context):
+        hook = NextflowTowerHook(context["params"]["tower_conn_id"])
+        info = LaunchInfo(
+            run_name=context["params"]["tower_run_name"],
+            pipeline="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge",
+            revision="main",
+            profiles=["sage"],
+            entry_name="NF_SYNSTAGE",
+            workspace_secrets=["SYNAPSE_AUTH_TOKEN"],
+            params={
+                "view_id": context["params"]["tower_view_id"],
+                "input_id": context["params"]["tower_input_id"],
+            },
+        )
+        run_id = hook.ops.launch_workflow(
+            info, context["params"]["tower_compute_env_type"]
+        )
+        return run_id
+
+    @task.sensor(poke_interval=300, timeout=604800, mode="reschedule")
+    def monitor_model2data_workflow(run_id: str, **context):
+        hook = NextflowTowerHook(context["params"]["tower_conn_id"])
+        workflow = hook.ops.get_workflow(run_id)
+        print(f"Current workflow state: {workflow.status.state.value}")
+        return workflow.status.is_done
+
+    submission_check = check_for_new_submissions()
+    stop = stop_dag()
+    run_id = launch_model2data_workflow()
+    monitor = monitor_model2data_workflow(run_id=run_id)
+
+    submission_check >> [
+        run_id,
+        stop,
+    ]
+    run_id >> monitor
+
+
+pegs_challenge_submission_dag()

--- a/dags/pegs-challenge-submission-dag.py
+++ b/dags/pegs-challenge-submission-dag.py
@@ -59,7 +59,7 @@ def pegs_challenge_submission_dag():
             pipeline="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge",
             revision="main",
             profiles=["sage"],
-            entry_name="NF_SYNSTAGE",
+            entry_name="MODEL_TO_DATA_CHALLENGE",
             workspace_secrets=["SYNAPSE_AUTH_TOKEN"],
             params={
                 "view_id": context["params"]["tower_view_id"],

--- a/dags/pegs-challenge-submission-dag.py
+++ b/dags/pegs-challenge-submission-dag.py
@@ -9,8 +9,8 @@ from orca.services.synapse import SynapseHook
 
 
 dag_params = {
-    "synapse_conn_id": Param("SYNAPSE_CHALLENGE_CONN", type="string"),
-    "synapse_evaluation_id": Param("9615511", type="string"),
+    "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
+    "synapse_evaluation_id": Param("9615531", type="string"),
     "tower_conn_id": Param("PEGS_CHALLENGE_PROJECT_TOWER_CONN", type="string"),
     "tower_run_name": Param("pegs_model_submission_evaluation", type="string"),
     "tower_view_id": Param("syn53239158", type="string"),
@@ -58,7 +58,6 @@ def pegs_challenge_submission_dag():
             run_name=context["params"]["tower_run_name"],
             pipeline="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge",
             revision="main",
-            profiles=["sage"],
             entry_name="MODEL_TO_DATA_CHALLENGE",
             workspace_secrets=["SYNAPSE_AUTH_TOKEN"],
             params={


### PR DESCRIPTION
### problem

The MODEL-TO-DATA Nextflow workflow should automatically execute at a regular cadence for the PEGS challenge Docker submissions.

### solution

Automate the execution of this process by wrapping it around an Airflow DAG that is configured to execute on a regular basis. The `start_date` and `schedule_interval` have not been modified. I'll make a separate PR to modify them once we have an exact start date for the challenge lined up.

### testing

Latest run of the DAG pointing at the `pegs-challenge-project` tower prod workspace:
https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/pegs-challenge-project/watch/2zROvZxyGZtybR

This DAG is currently pointed at the following Submissions view for testing: https://www.synapse.org/#!Synapse:syn53475818/tables/