### PR TITLE
[ORCA-304] Adding datasize and unique users

### DIFF
--- a/dags/top-downloads-from-sowflake.py
+++ b/dags/top-downloads-from-sowflake.py
@@ -2,7 +2,9 @@
 slack channel. This retrieved the top X publicly downloaded Synapse projects.
 See ORCA-301 for more context."""
 
+from dataclasses import dataclass
 from datetime import datetime
+from typing import List
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
@@ -26,7 +28,10 @@ dag_config = {
     "params": dag_params,
 }
 
-QUERY = """
+SIZE_ROUNDING = 3
+BYTE_STRING = "GiB"
+
+QUERY = f"""
 WITH PUBLIC_PROJECTS AS (
     SELECT
         node_latest.project_id,
@@ -65,7 +70,8 @@ DOWNLOAD_STAT AS (
         project_id,
         count(record_date) AS DOWNLOADS_PER_PROJECT,
         count(DISTINCT user_id) AS NUMBER_OF_UNIQUE_USERS_DOWNLOADED,
-        count(DISTINCT FD_FILE_HANDLE_ID) AS NUMBER_OF_UNIQUE_FILES_DOWNLOADED
+        count(DISTINCT FD_FILE_HANDLE_ID) AS NUMBER_OF_UNIQUE_FILES_DOWNLOADED,
+        ROUND(sum(content_size) / power(2, 30), {SIZE_ROUNDING}) as data_download_size
     FROM
         DEDUP_FILEHANDLE
     GROUP BY
@@ -74,7 +80,9 @@ DOWNLOAD_STAT AS (
 SELECT
     'https://www.synapse.org/#!Synapse:syn' || cast(DOWNLOAD_STAT.project_id as varchar) as project,
     DOWNLOAD_STAT.name,
-    DOWNLOAD_STAT.DOWNLOADS_PER_PROJECT
+    DOWNLOAD_STAT.DOWNLOADS_PER_PROJECT,
+    DOWNLOAD_STAT.data_download_size,
+    DOWNLOAD_STAT.NUMBER_OF_UNIQUE_USERS_DOWNLOADED
 FROM
     DOWNLOAD_STAT
 ORDER BY
@@ -83,25 +91,66 @@ LIMIT 10;
 """
 
 
+@dataclass
+class DownloadMetric:
+    """Dataclass to hold the download metrics from Synapse.
+
+    Attributes:
+        name: The name of the project
+        project: The URL of the project
+        downloads_per_project: The number of downloads per project
+        number_of_unique_users_downloaded: The number of unique users who downloaded
+        data_download_size: The size of the data downloaded
+
+    """
+
+    name: str
+    project: str
+    downloads_per_project: int
+    number_of_unique_users_downloaded: int
+    data_download_size: float
+
+
 @dag(**dag_config)
 def snowflake_top_downloads_to_slack() -> None:
     """Execute a query on Snowflake and report the results to a slack channel."""
 
     @task
-    def get_top_downloads_from_snowflake(**context) -> str:
-        """Execute the query on Snowflake and return the results as a string."""
+    def get_top_downloads_from_snowflake(**context) -> List[DownloadMetric]:
+        """Execute the query on Snowflake and return the results."""
         snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
         cs.execute(QUERY)
         top_downloaded_df = cs.fetch_pandas_all()
 
-        message = ":synapse: Top Downloaded Public Synapse Projects Yesterday (UTC)!\n\n"
-        for index, row in top_downloaded_df.iterrows():
-            name = row["NAME"]
-            url = row["PROJECT"]
-            downloads = row["DOWNLOADS_PER_PROJECT"]
-            message += f"{index+1}. <{url}|{name}> - {downloads} downloads\n\n"
+        metrics = []
+        for _, row in top_downloaded_df.iterrows():
+            metrics.append(
+                DownloadMetric(
+                    name=row["NAME"],
+                    project=row["PROJECT"],
+                    downloads_per_project=row["DOWNLOADS_PER_PROJECT"],
+                    number_of_unique_users_downloaded=row[
+                        "NUMBER_OF_UNIQUE_USERS_DOWNLOADED"
+                    ],
+                    data_download_size=row["DATA_DOWNLOAD_SIZE"],
+                )
+            )
+        return metrics
+
+    @task
+    def generate_top_downloads_message(metrics: List[DownloadMetric]) -> str:
+        """Generate the message to be posted to the slack channel."""
+        message = ":synapse: Top Downloaded Public Synapse Projects Yesterday!\n\n"
+        for index, row in enumerate(metrics):
+            if row.data_download_size:
+                size_string = (
+                    f"{row.data_download_size:.{SIZE_ROUNDING}f} {BYTE_STRING}"
+                )
+            else:
+                size_string = f"< {0:.{SIZE_ROUNDING}f}5 {BYTE_STRING}"
+            message += f"{index+1}. <{row.project}|{row.name}> - {row.downloads_per_project} downloads, {row.number_of_unique_users_downloaded} unique users, {size_string} {BYTE_STRING} egressed\n\n"
         message += "One download is a user downloading a file once\n"
         return message
 
@@ -113,9 +162,11 @@ def snowflake_top_downloads_to_slack() -> None:
         return result
 
     top_downloads = get_top_downloads_from_snowflake()
-    post_to_slack = post_top_downloads_to_slack(message=top_downloads)
+    slack_message = generate_top_downloads_message(metrics=top_downloads)
+    print(slack_message)
+    # post_to_slack = post_top_downloads_to_slack(message=slack_message)
 
-    top_downloads >> post_to_slack
+    # top_downloads >> slack_message >> post_to_slack
 
 
 snowflake_top_downloads_to_slack()

--- a/dags/top-downloads-from-sowflake.py
+++ b/dags/top-downloads-from-sowflake.py
@@ -153,7 +153,7 @@ def snowflake_top_downloads_to_slack() -> None:
             else:
                 size_string = f"< {0:.{SIZE_ROUNDING}f}5 {BYTE_STRING}"
             message += f"{index+1}. <https://www.synapse.org/#!Synapse:{row.project}|{row.name}> - {row.downloads_per_project} downloads, {row.number_of_unique_users_downloaded} unique users, {size_string} {BYTE_STRING} egressed\n\n"
-        message += "One download is a user downloading a file once\n"
+        message += "One download is a user downloading an entity (File, Table, Views, etc) once\n"
         return message
 
     @task


### PR DESCRIPTION
Problem:

1. We want to include the unique users and data size in the slack message

Solution:

1. Adding this data to the snowflake query and include it in the slack message

Testing:

1. Verified that printing data to console is giving back the expected data:
```
:synapse: Top Downloaded Public Synapse Projects Yesterday!
1. <https://www.synapse.org/#!Synapse:syn51364943|UKB-PPP> - 5647 downloads, 10 unique users, 3511.309 GiB GiB egressed
2. <https://www.synapse.org/#!Synapse:syn18779624|Robust  Medical Instrument Segmentation (ROBUST-MIS) Challenge 2019> - 4833 downloads, 1 unique users, 143.069 GiB GiB egressed
3. <https://www.synapse.org/#!Synapse:syn2759792|CommonMind Consortium Knowledge Portal> - 2719 downloads, 3 unique users, 2819.233 GiB GiB egressed
4. <https://www.synapse.org/#!Synapse:syn2580853|AD Knowledge Portal - backend> - 1991 downloads, 19 unique users, 4609.195 GiB GiB egressed
5. <https://www.synapse.org/#!Synapse:syn4921369|PsychENCODE Knowledge Portal - backend> - 1540 downloads, 10 unique users, 2925.087 GiB GiB egressed
6. <https://www.synapse.org/#!Synapse:syn26642505|Multimodal integration of radiology, pathology, and genomics for prediction of response to PD-L1 blockade in patients with non-small cell lung cancer> - 995 downloads, 1 unique users, 24.176 GiB GiB egressed
7. <https://www.synapse.org/#!Synapse:syn3193805|Multi-Atlas Labeling Beyond the Cranial Vault - Workshop and Challenge> - 646 downloads, 6 unique users, 102.776 GiB GiB egressed
8. <https://www.synapse.org/#!Synapse:syn25314439|AdaptOR Challenge 2021 (MICCAI)> - 556 downloads, 1 unique users, 0.081 GiB GiB egressed
9. <https://www.synapse.org/#!Synapse:syn51549340|BrainLat_dataset> - 275 downloads, 2 unique users, 16.898 GiB GiB egressed
10. <https://www.synapse.org/#!Synapse:syn49637038|SINGLE-CELL ATLAS OF HUMAN BLOOD DURING HEALTHY AGING> - 141 downloads, 3 unique users, 4554.683 GiB GiB egressed
One download is a user downloading a file once
```

Compared to previous version of the code:
```
:synapse: Top Downloaded Public Synapse Projects Yesterday (UTC)!
1. <https://www.synapse.org/#!Synapse:syn51364943|UKB-PPP> - 5647 downloads
2. <https://www.synapse.org/#!Synapse:syn18779624|Robust  Medical Instrument Segmentation (ROBUST-MIS) Challenge 2019> - 4833 downloads
3. <https://www.synapse.org/#!Synapse:syn2759792|CommonMind Consortium Knowledge Portal> - 2719 downloads
4. <https://www.synapse.org/#!Synapse:syn2580853|AD Knowledge Portal - backend> - 1991 downloads
5. <https://www.synapse.org/#!Synapse:syn4921369|PsychENCODE Knowledge Portal - backend> - 1540 downloads
6. <https://www.synapse.org/#!Synapse:syn26642505|Multimodal integration of radiology, pathology, and genomics for prediction of response to PD-L1 blockade in patients with non-small cell lung cancer> - 995 downloads
7. <https://www.synapse.org/#!Synapse:syn3193805|Multi-Atlas Labeling Beyond the Cranial Vault - Workshop and Challenge> - 646 downloads
8. <https://www.synapse.org/#!Synapse:syn25314439|AdaptOR Challenge 2021 (MICCAI)> - 556 downloads
9. <https://www.synapse.org/#!Synapse:syn51549340|BrainLat_dataset> - 275 downloads
10. <https://www.synapse.org/#!Synapse:syn49637038|SINGLE-CELL ATLAS OF HUMAN BLOOD DURING HEALTHY AGING> - 141 downloads
One download is a user downloading a file once
```