### PR TITLE
[ORCA-316] Fix `snowflake-connector-python` version

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -7,7 +7,7 @@ source venv/bin/activate
 # Upgrade pip to latest version
 pip install --upgrade pip
 # Install airflow with constraints
-pip install apache-airflow[amazon,celery,snowflake]==2.7.2 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt"
+pip install apache-airflow==2.7.2 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt"
 # Install other dependencies
 pip install -r requirements-airflow.txt
 # Install dev dependencies

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,3 +1,6 @@
+apache-airflow-providers-amazon ~=7.2
+apache-airflow-providers-celery >=3.0
+apache-airflow-providers-snowflake ~=5.2
 py-orca[all] == 1.3.4
 pandas ~=2.0.0
 slack-sdk >=3.27

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,6 +1,7 @@
 apache-airflow-providers-amazon ~=7.2
 apache-airflow-providers-celery >=3.0
 apache-airflow-providers-snowflake ~=5.2
+snowflake-connector-python ~=3.7
 py-orca[all] == 1.3.4
 pandas ~=2.0.0
 slack-sdk >=3.27


### PR DESCRIPTION
**Problem:**

We recently updated our dependency management strategy for this repository. When we made this update, it appears that it caused and older version of `snowflake-connector-python` to be installed in the Airflow deployment which led to the top charts DAG hanging mid-run.

**Solution:**

Explicitly set the version of `snowflake-connector-python` in `requirements-airflow.txt`. I also went ahead and pinned the provider versions in `requirements-airflow.txt` like we used to in the old `pipfile`.

**Testing:**

- I ran the top charts DAG in the development environment and it [worked](https://sagebionetworks.slack.com/archives/C06KHDY55QR/p1712184891139389). 
- I also manually ran through all of our dependencies (`apache-airflow` + `requirements-airflow.txt` + `requirements-dev.txt`) installed in the Airflow deployment and local development environment to ensure that compatible package versions are being installed.
