### PR TITLE
hotfix: Fix KeyError in PEGS DAG

### DIFF
--- a/dags/pegs-challenge-submission-dag.py
+++ b/dags/pegs-challenge-submission-dag.py
@@ -46,7 +46,7 @@ def pegs_challenge_submission_dag():
     def get_new_submissions(**context) -> list[int]:
         hook = SynapseHook(context["params"]["synapse_conn_id"])
         submissions = hook.ops.get_submissions_with_status(
-            context["params"]["view_id"], "RECEIVED"
+            context["params"]["tower_view_id"], "RECEIVED"
         )
         return submissions
 


### PR DESCRIPTION
The PEGS Challenge DAG was failing at the start due to a KeyError (no such key as 'view_id')