### PR TITLE
[IBCDPE-907] Sort by unique user count instead of downloads

### DIFF
--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -128,7 +128,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
             FROM
                 DOWNLOAD_STAT
             ORDER BY
-                DOWNLOADS_PER_PROJECT DESC NULLS LAST
+                NUMBER_OF_UNIQUE_USERS_DOWNLOADED DESC NULLS LAST
             """
         cs.execute(query)
         top_downloaded_df = cs.fetch_pandas_all()


### PR DESCRIPTION
Problem:

1. Downloads are sorted by number of files being downloaded

Solution:

1. Sorting by number of unique users instead

Testing:

1. Verified that the query executes as expected in snowflake:
![image](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/assets/17128019/4e698d62-c241-4462-98ac-2e2ecc956234)
