### PR TITLE
[SNOW-98] Add Trending Snapshots DAG

### DIFF
--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -112,7 +112,7 @@ def trending_projects_snapshot() -> None:
                     SELECT ID, PROJECT_ID, FILE_HANDLE_ID
                     FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.NODE_LATEST
                     WHERE 1=1
-                    AND DATE_TRUNC('MONTH', CHANGE_TIMESTAMP) <= DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
+                    AND DATE_TRUNC('MONTH', CREATED_ON) <= DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
                     AND NODE_TYPE = 'file'
                     AND PROJECT_ID IN (SELECT PROJECT_ID FROM TOP_10_PUBLIC_PROJECTS)
                 ),

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -174,10 +174,10 @@ def trending_projects_snapshot() -> None:
             synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
         )
 
-    top_downloads = get_trending_project_snapshot()
-    push_to_synapse_table = push_results_to_synapse_table(metrics=top_downloads)
+    project_snapshot = get_trending_project_snapshot()
+    push_to_synapse_table = push_results_to_synapse_table(metrics=project_snapshot)
 
-    top_downloads >> push_to_synapse_table
+    project_snapshot >> push_to_synapse_table
 
 
 trending_projects_snapshot()

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -30,7 +30,7 @@ dag_params = {
     "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
-    "month_to_run": Param((date.today() - relativedelta(months=0)).strftime("%Y-%m-%d"), type="string")
+    "month_to_run": Param((date.today() - relativedelta(months=1)).strftime("%Y-%m-%d"), type="string")
     }
 
 dag_config = {

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -23,7 +23,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from orca.services.synapse import SynapseHook
 
 
-SYNAPSE_RESULTS_TABLE = "syn61932294"
+SYNAPSE_RESULTS_TABLE = "syn61597055"
 
 dag_params = {
     "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
@@ -34,7 +34,7 @@ dag_params = {
 
 dag_config = {
     # run on the 2nd of every month at midnight
-    "schedule_interval": "*/1 * * * *",
+    "schedule_interval": "0 0 2 * *",
     "start_date": datetime(2024, 1, 1),
     "catchup": False,
     "default_args": {

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -91,7 +91,7 @@ def trending_projects_snapshot() -> None:
                     FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.NODE_LATEST
                     WHERE 1=1
                     AND NODE_TYPE = 'project'
-                    AND IS_PUBLIC = TRUE
+                    AND IS_PUBLIC
                 ),
                 RECENT_DOWNLOADS AS (
                     SELECT PROJECT_ID, RECORD_DATE, USER_ID

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -96,7 +96,8 @@ def trending_projects_snapshot() -> None:
                 RECENT_DOWNLOADS AS (
                     SELECT PROJECT_ID, RECORD_DATE, USER_ID
                     FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.FILEDOWNLOAD
-                    WHERE DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE({context["params"]["month_to_run"]}))
+                    WHERE 1=1
+                    AND DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
                     AND STACK = 'prod'
                     AND PROJECT_ID IN (SELECT PROJECT_ID FROM PUBLIC_PROJECTS)
                 ),
@@ -142,7 +143,7 @@ def trending_projects_snapshot() -> None:
                     FILE_SIZES.TOTAL_DATA_SIZE_IN_GIB
 
                 ORDER BY 
-                    TOP_10_PUBLIC_PROJECTS.N_UNIQUE_USERS DESC;
+                    TOP_10_PUBLIC_PROJECTS.N_UNIQUE_USERS DESC
             """
 
         cs.execute(query)

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -110,29 +110,27 @@ def trending_projects_snapshot() -> None:
                     SELECT PROJECT_ID, RECORD_DATE, USER_ID
                     FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.FILEDOWNLOAD
                     WHERE 1=1
-                    AND RECORD_DATE > DATEADD(DAY, -{context["params"]["time_window"]}, CURRENT_DATE()) 
+                    AND RECORD_DATE > DATEADD(DAY, -{context["params"]["time_window"]}, CURRENT_DATE())
                     AND STACK = 'prod'
                     AND PROJECT_ID IN (SELECT PROJECT_ID FROM PUBLIC_PROJECTS)
                 )
 
                 SELECT 
-                    pp.PROJECT_ID,
-                    COUNT(DISTINCT rd.USER_ID) AS N_UNIQUE_USERS,
-                    COALESCE(TO_CHAR(MAX(rd.RECORD_DATE), 'YYYY-MM-DD'), 'N/A') AS LAST_DOWNLOAD_DATE,
-                    ROUND(fs.TOTAL_DATA_SIZE_IN_GIB, 3) AS TOTAL_DATA_SIZE_IN_GIB
+                    PUBLIC_PROJECTS.PROJECT_ID,
+                    COUNT(DISTINCT RECENT_DOWNLOADS.USER_ID) AS N_UNIQUE_USERS,
+                    COALESCE(TO_CHAR(MAX(RECENT_DOWNLOADS.RECORD_DATE), 'YYYY-MM-DD'), 'N/A') AS LAST_DOWNLOAD_DATE,
+                    ROUND(FILE_SIZES.TOTAL_DATA_SIZE_IN_GIB, 3) AS TOTAL_DATA_SIZE_IN_GIB
                 FROM 
-                    PUBLIC_PROJECTS pp
+                    PUBLIC_PROJECTS
 
-                -- Join RECENT_DOWNLOADS
-                LEFT JOIN RECENT_DOWNLOADS rd
-                ON pp.PROJECT_ID = rd.PROJECT_ID
+                LEFT JOIN RECENT_DOWNLOADS
+                ON PUBLIC_PROJECTS.PROJECT_ID = RECENT_DOWNLOADS.PROJECT_ID
 
-                -- Join FILE_SIZES
-                LEFT JOIN FILE_SIZES fs
-                ON pp.PROJECT_ID = fs.PROJECT_ID
+                LEFT JOIN FILE_SIZES
+                ON PUBLIC_PROJECTS.PROJECT_ID = FILE_SIZES.PROJECT_ID
 
                 GROUP BY
-                    pp.PROJECT_ID, fs.TOTAL_DATA_SIZE_IN_GIB
+                    PUBLIC_PROJECTS.PROJECT_ID, FILE_SIZES.TOTAL_DATA_SIZE_IN_GIB
                 ORDER BY 
                     N_UNIQUE_USERS DESC
                 LIMIT 10;

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -157,7 +157,7 @@ def trending_snapshots() -> None:
     def push_results_to_synapse_table(metrics: List[SnapshotMetrics], **context) -> None:
         """Push the results to a Synapse table."""
         data = []
-        today = date.today()
+        export_date = date.today()
         for metric in metrics:
             data.append(
                 [
@@ -165,7 +165,7 @@ def trending_snapshots() -> None:
                     metric.n_unique_users,
                     metric.last_download_date,
                     metric.total_data_size_in_gib,
-                    today
+                    export_date
                 ]
             )
 

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -34,8 +34,8 @@ dag_params = {
 
 dag_config = {
     # run on the 1st of every month at midnight
-    "schedule_interval": "0 0 1 * *",
-    "start_date": datetime(2024, 7, 1),
+    "schedule_interval": "*/1 * * * *",
+    "start_date": datetime(2024, 1, 1),
     "catchup": False,
     "default_args": {
         "retries": 1,
@@ -93,8 +93,8 @@ def trending_snapshots() -> None:
 
                 SELECT 
                     recent_downloads.PROJECT_ID, 
-                    COUNT(DISTINCT recent_downloads.USER_ID) AS unique_users,
-                    MAX(recent_downloads.RECORD_DATE) AS last_download_date,
+                    COUNT(DISTINCT recent_downloads.USER_ID) AS UNIQUE_USERS,
+                    MAX(recent_downloads.RECORD_DATE) AS LAST_DOWNLOAD_DATE,
                     SUM(file_latest.CONTENT_SIZE) / POWER(1024, 3) AS TOTAL_DATA_SIZE_IN_GIB
 
                 -- Select the table you want to curate from
@@ -128,10 +128,10 @@ def trending_snapshots() -> None:
         for _, row in top_downloaded_df.iterrows():
             metrics.append(
                 SnapshotsMetric(
-                    project_id=row["project_id"],
-                    n_unique_users=row["n_unique_users"],
-                    last_download_date=row["last_download_date"],
-                    total_data_size_in_gib=row["total_data_size_in_gib"],
+                    project_id=row["PROJECT_ID"],
+                    n_unique_users=row["UNIQUE_USERS"],
+                    last_download_date=row["LAST_DOWNLOAD_DATE"],
+                    total_data_size_in_gib=row["TOTAL_DATA_SIZE_IN_GIB"],
                 )
             )
         return metrics

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -1,0 +1,166 @@
+"""
+This script is used to execute a query on Snowflake and report the results to a 
+Synapse table. This DAG updates the Trending Snapshots Synapse table
+(https://www.synapse.org/Synapse:syn61597055/tables/) every month with the following metrics:
+
+- Top 10 Projects with the most unique users
+- Number of unique users
+- Last download date
+- Total data size (in GiB) for each project
+- Export date (the last time this table was updated)
+"""
+
+from airflow.decorators import dag
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import List
+
+import synapseclient
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from orca.services.synapse import SynapseHook
+
+
+SYNAPSE_RESULTS_TABLE = "syn61597055"
+
+dag_params = {
+    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
+    "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
+    "time_window": Param("30d", type="string"),
+    }
+
+dag_config = {
+    # run on the 1st of every month at midnight
+    "schedule_interval": "0 0 1 * *",
+    "start_date": datetime(2024, 7, 1),
+    "catchup": False,
+    "default_args": {
+        "retries": 1,
+    },
+    "tags": ["snowflake"],
+    "params": dag_params,
+}
+
+
+@dataclass
+class SnapshotsMetric:
+    """
+    Dataclass to hold the download metrics from Synapse.
+
+    Attributes:
+        total_data_size_in_pib: The size of the data hosted on Synapse in PiB
+        active_users_last_month: The number of active users last month
+        total_downloads_last_month: The total number of downloads by users last month
+    """
+
+    project_id: float
+    n_unique_users: int
+    last_download_date: int
+    total_data_size_in_gib: float
+
+
+@dag(**dag_config)
+def trending_snapshots() -> None:
+    """
+    """
+
+    @task
+    def get_trending_snapshots(**context) -> List[SnapshotsMetric]:
+        """Execute the query on Snowflake and return the results."""
+        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        ctx = snow_hook.get_conn()
+        cs = ctx.cursor()
+        query = f"""
+                WITH RECENT_DOWNLOADS AS (
+                    SELECT *
+                    FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.FILEDOWNLOAD
+                    WHERE 1=1
+                    AND RECORD_DATE > DATEADD(DAY, -28, '2024-06-26') 
+                    AND RECORD_DATE <= '2024-06-26'
+                    AND STACK = 'prod'
+                    AND PROJECT_ID IS NOT NULL
+                ),
+                PUBLIC_PROJECTS AS (
+                    SELECT NAME, PROJECT_ID
+                    FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.NODE_LATEST
+                    WHERE 1=1
+                    AND NODE_TYPE = 'project'
+                    AND IS_PUBLIC = TRUE
+                )
+
+                SELECT 
+                    recent_downloads.PROJECT_ID, 
+                    COUNT(DISTINCT recent_downloads.USER_ID) AS unique_users,
+                    MAX(recent_downloads.RECORD_DATE) AS last_download_date,
+                    SUM(file_latest.CONTENT_SIZE) / POWER(1024, 3) AS TOTAL_DATA_SIZE_IN_GIB
+
+                -- Select the table you want to curate from
+                FROM 
+                    RECENT_DOWNLOADS recent_downloads
+
+                -- Join FILE_LATEST
+                JOIN 
+                    SYNAPSE_DATA_WAREHOUSE.SYNAPSE.FILE_LATEST file_latest
+                ON 
+                    recent_downloads.FILE_HANDLE_ID = file_latest.ID
+
+                -- Join PUBLIC_PROJECTS
+                JOIN
+                    PUBLIC_PROJECTS public_projects
+                ON
+                    recent_downloads.PROJECT_ID = public_projects.PROJECT_ID
+
+                -- Sorting the final table for calculation
+                GROUP BY
+                    recent_downloads.PROJECT_ID
+                ORDER BY 
+                    unique_users DESC
+                LIMIT 10;
+            """
+
+        cs.execute(query)
+        top_downloaded_df = cs.fetch_pandas_all()
+
+        metrics = []
+        for _, row in top_downloaded_df.iterrows():
+            metrics.append(
+                SnapshotsMetric(
+                    project_id=row["project_id"],
+                    n_unique_users=row["n_unique_users"],
+                    last_download_date=row["last_download_date"],
+                    total_data_size_in_gib=row["total_data_size_in_gib"],
+                )
+            )
+        return metrics
+
+    @task
+    def push_results_to_synapse_table(metrics: List[SnapshotsMetric], **context) -> None:
+        """Push the results to a Synapse table."""
+        data = []
+        today = date.today()
+        for metric in metrics:
+            data.append(
+                [
+                    metric.project_id,
+                    metric.n_unique_users,
+                    metric.last_download_date,
+                    metric.total_data_size_in_gib,
+                    today
+                ]
+            )
+
+        syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
+        syn_hook.client.store(
+            synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
+        )
+
+    top_downloads = get_trending_snapshots()
+    push_to_synapse_table = push_results_to_synapse_table(metrics=top_downloads)
+
+    top_downloads >> push_to_synapse_table
+
+
+trending_snapshots()

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -29,7 +29,7 @@ dag_params = {
     "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
-    "time_window": Param("2", type="string"),
+    "time_window": Param("30", type="string"),
     }
 
 dag_config = {

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -23,7 +23,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from orca.services.synapse import SynapseHook
 
 
-SYNAPSE_RESULTS_TABLE = "syn61597055"
+SYNAPSE_RESULTS_TABLE = "syn61932294"
 
 dag_params = {
     "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -33,7 +33,7 @@ dag_params = {
     }
 
 dag_config = {
-    # run on the 1st of every month at midnight
+    # run on the 2nd of every month at midnight
     "schedule_interval": "*/1 * * * *",
     "start_date": datetime(2024, 1, 1),
     "catchup": False,
@@ -119,7 +119,7 @@ def trending_snapshots() -> None:
                     pp.PROJECT_ID,
                     COUNT(DISTINCT rd.USER_ID) AS N_UNIQUE_USERS,
                     COALESCE(TO_CHAR(MAX(rd.RECORD_DATE), 'YYYY-MM-DD'), 'N/A') AS LAST_DOWNLOAD_DATE,
-                    fs.TOTAL_DATA_SIZE_IN_GIB
+                    ROUND(fs.TOTAL_DATA_SIZE_IN_GIB, 3) AS TOTAL_DATA_SIZE_IN_GIB
                 FROM 
                     PUBLIC_PROJECTS pp
 

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -23,7 +23,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from orca.services.synapse import SynapseHook
 
 
-SYNAPSE_RESULTS_TABLE = "syn61942766"
+SYNAPSE_RESULTS_TABLE = "syn61932294"
 
 dag_params = {
     "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),

--- a/dags/trending-snapshots-dag.py
+++ b/dags/trending-snapshots-dag.py
@@ -134,7 +134,7 @@ def trending_snapshots() -> None:
                 GROUP BY
                     pp.PROJECT_ID, fs.TOTAL_DATA_SIZE_IN_GIB
                 ORDER BY 
-                    UNIQUE_USERS DESC
+                    N_UNIQUE_USERS DESC
                 LIMIT 10;
             """
 


### PR DESCRIPTION
This DAG will automate populating the [Trending Projects Snapshots table](https://www.synapse.org/Synapse:syn61597055/tables/) at the users' desired cadence.

- [x] Successful initial run of DAG on Trending Snapshots Test
- [x] Fix calculation of `TOTAL_DATA_SIZE_IN_GIB`
- [x] Revert changes made for debugging ( date, time window )
- [x] Clean up DAG script ( refactor, document, etc )

## testing

### 1 : Test query efficacy
Testing the query on [this test Project](https://www.synapse.org/Synapse:syn57428232/files/) ensures that the project size (i.e. the total number of File entities stored within a project) is being calculated correctly:

<img width="829" alt="image" src="https://github.com/user-attachments/assets/da1a642a-2322-4762-a805-0c3dce38841f">

----

### 2 : Test query efficacy
Confirming the query results for the 30 days leading up to 6/29/2024 approach the results from the initial query

** Current query results **
<img width="970" alt="image" src="https://github.com/user-attachments/assets/10077af6-0cfd-4dcb-9aa4-d03187b1b60e">

** Initial query results **
<img width="779" alt="image" src="https://github.com/user-attachments/assets/2847ae04-5b78-42bd-9e94-7badeb6dd784">

----

### 3 : Test query efficacy
This query also accounts for cases where there are no new downloads / users within the time range specified (thanks to `LEFT JOIN`)

<img width="981" alt="image" src="https://github.com/user-attachments/assets/9a1c051a-86b2-4975-a16c-c9234b243c6f">

----

### 4 : Test DAG functionality
[Trending Snapshots Test](https://www.synapse.org/Synapse:syn61932294/tables/)

----

### 5 : Test DAG functionality

I changed `time_window` in the `dag_config` to 2 days to ensure the `n_unique_users` reflects this shorter time window. Results:

[Trending Snapshots Test 2 days](https://www.synapse.org/Synapse:syn61942766/tables/)