### PR TITLE
Update synapse-by-the-numbers-dag.py to run on the 2nd of every month

### DIFF
--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -21,7 +21,7 @@ dag_params = {
 }
 
 dag_config = {
-    # run on the 1st of every month at midnight
+    # run on the 2nd of every month at midnight
     "schedule_interval": "0 0 2 * *",
     "start_date": datetime(2024, 7, 1),
     "catchup": False,

--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -22,7 +22,7 @@ dag_params = {
 
 dag_config = {
     # run on the 1st of every month at midnight
-    "schedule_interval": "0 0 1 * *",
+    "schedule_interval": "0 0 2 * *",
     "start_date": datetime(2024, 7, 1),
     "catchup": False,
     "default_args": {


### PR DESCRIPTION
**Problem:**

Our DAG running on the 1st of every month at midnight UTC may cause the queried results to be inaccurate and it is confusing because the data appears under a record for the last day of the prior month (when viewed in a local timezone).

**Solution:**

Change this so that the DAG runs on the 2nd of every month at midnight instead.