### PR TITLE
[SNOW-139] Filters Homepage Metrics In Synapse Download Metrics DAGS

### DIFF
--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -1,5 +1,5 @@
 """This script is used to execute a query on Snowflake and report the results to a 
-Synapse table. This retrieves download metrics for Public Synapse Projects for the past 30 days.
+Synapse table. This retrieves download metrics for Public Synapse Projects excluding the Synapse Homepage Project for the past 30 days.
 It is scheduled to run at 00:00 every day."""
 
 from dataclasses import dataclass
@@ -31,6 +31,7 @@ dag_config = {
 }
 
 SYNAPSE_RESULTS_TABLE = "syn55382267"
+SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 
 @dataclass
@@ -72,7 +73,8 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
                     synapse_data_warehouse.synapse.node_latest
                 WHERE
                     node_latest.is_public AND
-                    node_latest.node_type = 'project'
+                    node_latest.node_type = 'project' AND
+                    node_latest.project_id != {SYNAPSE_HOMEPAGE_PROJECT_ID}
             ),
             DEDUP_FILEHANDLE AS (
                 SELECT DISTINCT

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -1,7 +1,7 @@
 """This script is used to execute a query on Snowflake and report the results to a
 slack channel and Synapse table. 
-This retrieves the top X publicly downloaded Synapse projects for slack.
-This retrieves all publicly downloaded Synapse projects for the Synapse table.
+This retrieves the top X publicly downloaded Synapse projects excluding the Synapse Homepage Project for slack.
+This retrieves all publicly downloaded Synapse projects excluding the Synapse Homepage Project for the Synapse table.
 See ORCA-301 for more context."""
 
 from dataclasses import dataclass
@@ -43,6 +43,7 @@ BYTE_STRING = "GiB"
 POWER_OF_TWO = 30
 
 SYNAPSE_RESULTS_TABLE = "syn53696951"
+SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 
 @dataclass
@@ -90,7 +91,8 @@ def top_public_synapse_projects_from_snowflake() -> None:
                     synapse_data_warehouse.synapse.node_latest
                 WHERE
                     node_latest.is_public AND
-                    node_latest.node_type = 'project'
+                    node_latest.node_type = 'project' AND
+                    node_latest.project_id != {SYNAPSE_HOMEPAGE_PROJECT_ID}
             ),
             DEDUP_FILEHANDLE AS (
                 SELECT DISTINCT

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -3,7 +3,7 @@ This script is used to execute a query on Snowflake and report the results to a
 Synapse table. This DAG updates the Trending Projects Snapshots Synapse table
 (https://www.synapse.org/Synapse:syn61597055/tables/) every X number of days with the following metrics:
 
-- Top 10 Projects with the most unique users
+- Top 10 Projects (excluding the Synapse Homepage Project) with the most unique users
 - Number of unique users
 - Last download date
 - Total data size (in GiB) for each project
@@ -25,6 +25,7 @@ from orca.services.synapse import SynapseHook
 
 
 SYNAPSE_RESULTS_TABLE = "syn61597055"
+SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 dag_params = {
     "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
@@ -92,6 +93,7 @@ def trending_projects_snapshot() -> None:
                     WHERE 1=1
                     AND NODE_TYPE = 'project'
                     AND IS_PUBLIC
+                    AND PROJECT_ID != {SYNAPSE_HOMEPAGE_PROJECT_ID}
                 ),
                 RECENT_DOWNLOADS AS (
                     SELECT PROJECT_ID, RECORD_DATE, USER_ID


### PR DESCRIPTION
**Description:**

This PR adds updates the queries in 4 Airflow DAGs which pull project-specific metrics from Snowflake and pushes those metrics into Synapse to exclude the "[Synapse Homepage Data](https://www.synapse.org/#!Synapse:syn23593546)" project. This will prevent metrics from the homepage from appearing in the "Trending Projects" section displayed on the Homepage itself. 