### PR TITLE
[IBCDPE-1111] Update dockerfile install for latest airflow instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-ARG BASE_IMAGE=apache/airflow:2.7.2-python3.10
+ARG BASE_IMAGE=apache/airflow:2.9.3-python3.10
 FROM $BASE_IMAGE
 
 RUN pip install --upgrade pip
 
-RUN pip install apache-airflow[amazon,celery,snowflake]==2.7.2 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt"
+RUN pip install apache-airflow[amazon,celery,snowflake]==2.9.3 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.10.txt"
 
 COPY requirements-airflow.txt /tmp/requirements-airflow.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-airflow.txt
+
+USER root
+RUN apt-get update
+RUN apt-get -y install git
+
+# change back to base image user
+USER 50000
+
+# Installed from git a version of py-orca that is compatible with the version of the airflow image
+RUN pip install -e git+https://github.com/Sage-Bionetworks-Workflows/py-orca@7c4781c4750ca8025deb1c6665730d7d46844fbc#egg=py-orca[all]
 
 COPY requirements-dev.txt /tmp/requirements-dev.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,5 @@ RUN pip install apache-airflow[amazon,celery,snowflake]==2.9.3 --constraint "htt
 COPY requirements-airflow.txt /tmp/requirements-airflow.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-airflow.txt
 
-USER root
-RUN apt-get update
-RUN apt-get -y install git
-
-# change back to base image user
-USER 50000
-
-# Installed from git a version of py-orca that is compatible with the version of the airflow image
-RUN pip install -e git+https://github.com/Sage-Bionetworks-Workflows/py-orca@7c4781c4750ca8025deb1c6665730d7d46844fbc#egg=py-orca[all]
-
 COPY requirements-dev.txt /tmp/requirements-dev.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -7,7 +7,7 @@ source venv/bin/activate
 # Upgrade pip to latest version
 pip install --upgrade pip
 # Install airflow with constraints
-pip install apache-airflow==2.7.2 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.7.2/constraints-3.10.txt"
+pip install apache-airflow==2.9.3 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.10.txt"
 # Install other dependencies
 pip install -r requirements-airflow.txt
 # Install dev dependencies

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,7 +1,9 @@
-apache-airflow-providers-amazon ~=7.2
-apache-airflow-providers-celery >=3.0
-apache-airflow-providers-snowflake ~=5.2
-snowflake-connector-python ~=3.7
-py-orca[all] == 1.3.4
-pandas ~=2.0.0
+apache-airflow-providers-amazon ~=8.25
+apache-airflow-providers-celery >=3.7
+apache-airflow-providers-snowflake ~=5.6
+snowflake-connector-python ~=3.11
+# Installed in Dockerfile - Should be updated to use version from PYPI when ready
+# py-orca[all] @ git+https://github.com/Sage-Bionetworks-Workflows/py-orca@7c4781c4750ca8025deb1c6665730d7d46844fbc#egg=py-orca[all]
+pandas <3.0.0
 slack-sdk >=3.27
+pendulum<3.0.0

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -2,8 +2,7 @@ apache-airflow-providers-amazon ~=8.25
 apache-airflow-providers-celery >=3.7
 apache-airflow-providers-snowflake ~=5.6
 snowflake-connector-python ~=3.11
-# Installed in Dockerfile - Should be updated to use version from PYPI when ready
-# py-orca[all] @ git+https://github.com/Sage-Bionetworks-Workflows/py-orca@7c4781c4750ca8025deb1c6665730d7d46844fbc#egg=py-orca[all]
+py-orca[all] == 1.4.0
 pandas <3.0.0
 slack-sdk >=3.27
 pendulum<3.0.0


### PR DESCRIPTION
**Problem:**

1. We are 1 year behind on airflow updates.
2. The current version of the airflow release has a few bugs in it's deployment via helm to kubernetes that cause the scheduler to fail and not recover.

**Solution:**

1. Update to 2.9.3 of airflow.
2. Install py-orca from a git hash since it previously had a dependency of 2.7.2 of airflow and was causing version downgrades.
3. Pin Pendulum dependency to <3 as it was causing startup issues.

**Testing:**

1. I deployed this out to the sandbox kubernetes cluster and verified that DAGs could run as expected.


**TODO:**

1. When/if we release https://github.com/Sage-Bionetworks-Workflows/py-orca/pull/45 we should remove the need to install the dependency via git hash and instead pull the version from PYPI.

Related PRs:

1. https://github.com/Sage-Bionetworks-Workflows/eks-stack/pull/42
2. https://github.com/Sage-Bionetworks-Workflows/py-orca/pull/45