### PR TITLE
[Snow-228] Created a DAG to get projects, datasets that were created in the past seven days 

### DIFF
--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -60,7 +60,7 @@ class EntityCreated:
     Attributes:
         name: The name of this entity.
         id: The unique immutable ID for this entity.
-        parent_id: parent id of the entity
+        project_id: project id of the entity
         node_type: Type of Node
         content_type: Content type of folder annotated,
         created_on: The date this entity was created.
@@ -71,7 +71,7 @@ class EntityCreated:
 
     name: str
     id: int
-    parent_id: int
+    project_id: int
     node_type: str
     content_type: str
     created_on: str
@@ -113,7 +113,7 @@ def datasets_or_projects_created_7_days() -> None:
         SELECT 
             name,
             n.id,
-            parent_id,
+            project_id,
             node_type,
             ARRAY_TO_STRING(annotations:annotations:contentType:value, ', ') as content_type,
             TO_DATE(n.created_on) as entity_created_date,
@@ -149,7 +149,7 @@ def datasets_or_projects_created_7_days() -> None:
                     name=row["NAME"],
                     id=row["ID"],
                     node_type=row["NODE_TYPE"],
-                    parent_id=row["PARENT_ID"],
+                    project_id=row["PROJECT_ID"],
                     content_type=row["CONTENT_TYPE"],
                     created_on=row["ENTITY_CREATED_DATE"],
                     user_name_full_name=row["USER_NAME_FULL_NAME"],
@@ -198,7 +198,7 @@ def datasets_or_projects_created_7_days() -> None:
                 [
                     row.name,
                     row.id,
-                    row.parent_id,
+                    row.project_id,
                     row.node_type,
                     row.content_type,
                     row.created_on,

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -64,6 +64,7 @@ class EntityCreated:
         node_type: Type of Node
         content_type: Content type of folder annotated,
         created_on: The date this entity was created.
+        full_name: Full name of the user that created this entity
         created_by: The ID of the user that created this entity.
         is_public: True to indicate if this entity is public.
     """

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -119,10 +119,10 @@ def datasets_or_projects_created_7_days() -> None:
         message = f":synapse: Datasets or projects created in the last 7 days \n\n"
         for index, row in enumerate(entity_created):
             if row.content_type:
-                type = row.content_type.strip("[] \n").strip('"')
+                data_type = row.content_type.strip("[] \n").strip('"')
             else:
-                type = row.node_type
-            message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|this user>, Public: {row.is_public})\n\n"
+                data_type = row.node_type
+            message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|this user>, Public: {row.is_public})\n\n"
         return message
 
     @task

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -175,7 +175,7 @@ def datasets_or_projects_created_7_days() -> None:
     def post_slack_messages(message: str) -> bool:
         """Post the top downloads to the slack channel."""
         client = WebClient(token=Variable.get("SLACK_DPE_TEAM_BOT_TOKEN"))
-        result = client.chat_postMessage(channel="hotdrop_test", text=message)
+        result = client.chat_postMessage(channel="hotdrops", text=message)
         print(f"Result of posting to slack: [{result}]")
         return result is not None
 
@@ -216,13 +216,13 @@ def datasets_or_projects_created_7_days() -> None:
     entity_created = get_datasets_projects_created_7_days()
     check = check_backfill()
     stop = stop_dag()
-    # push_to_synapse_table = push_results_to_synapse_table(entity_created=entity_created)
+    push_to_synapse_table = push_results_to_synapse_table(entity_created=entity_created)
     slack_message = generate_slack_message(entity_created=entity_created)
-    # post_to_slack = post_slack_messages(message=slack_message)
+    post_to_slack = post_slack_messages(message=slack_message)
 
     entity_created >> check >> [stop, slack_message]
-    # slack_message >> post_to_slack
-    # entity_created >> push_to_synapse_table
+    slack_message >> post_to_slack
+    entity_created >> push_to_synapse_table
 
 
 datasets_or_projects_created_7_days()

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -116,7 +116,7 @@ def datasets_or_projects_created_7_days() -> None:
     @task
     def generate_slack_message(entity_created: List[EntityCreated], **context) -> str:
         """Generate the message to be posted to the slack channel."""
-        message = f":synapse: Datasets or projects created in the last 7 days \n\n"
+        message = ":synapse: Datasets or projects created in the last 7 days \n\n"
         for index, row in enumerate(entity_created):
             if row.content_type:
                 data_type = row.content_type.strip("[] \n").strip('"')

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -50,7 +50,7 @@ dag_config = {
     "params": dag_params,
 }
 
-SYNAPSE_RESULTS_TABLE = "syn64919238"
+SYNAPSE_RESULTS_TABLE = "syn64951484"
 
 
 @dataclass
@@ -198,8 +198,8 @@ def datasets_or_projects_created_7_days() -> None:
                 [
                     row.name,
                     row.id,
-                    row.node_type,
                     row.parent_id,
+                    row.node_type,
                     row.content_type,
                     row.created_on,
                     row.created_by,

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -122,9 +122,6 @@ def datasets_or_projects_created_7_days() -> None:
             else:
                 type = row.node_type
             message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|this user>, Public: {row.is_public})\n\n"
-            if row.content_type:
-                logger.info("before cleanning", row.content_type)
-                logger.info("after stripping", type)
         return message
 
     @task

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -129,7 +129,7 @@ def datasets_or_projects_created_7_days() -> None:
     def post_slack_messages(message: str) -> bool:
         """Post the top downloads to the slack channel."""
         client = WebClient(token=Variable.get("SLACK_DPE_TEAM_BOT_TOKEN"))
-        result = client.chat_postMessage(channel="hotdrop_test", text=message)
+        result = client.chat_postMessage(channel="hotdrop", text=message)
         print(f"Result of posting to slack: [{result}]")
         return result is not None
 

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -1,5 +1,6 @@
-"""This script executes a query on Snowflake to retrieve data about entities created in the past 7 days and stores the results in a Synapse table. 
-It is scheduled to run every Monday at 00:00 UTC"""
+"""This script executes a query on Snowflake to retrieve data about entities created in the past 7 days and stores the results in a Synapse table.
+It is scheduled to run every Monday at 00:00 UTC.
+"""
 
 from dataclasses import dataclass
 from datetime import date, datetime

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -1,0 +1,145 @@
+"""This script executes a query on Snowflake to retrieve data about entities created in the past few days and stores the results in a Synapse table. 
+It is scheduled to run daily at 00:00."""
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import List
+
+import synapseclient
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from airflow.models.param import Param
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from orca.services.synapse import SynapseHook
+
+dag_params = {
+    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
+    "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
+}
+
+dag_config = {
+    "schedule_interval": "0 0 * * *",
+    "start_date": datetime(2025, 3, 1),
+    "catchup": False,
+    "default_args": {
+        "retries": 1,
+    },
+    "tags": ["snowflake"],
+    "params": dag_params,
+}
+
+SYNAPSE_RESULTS_TABLE = "syn64919238"
+
+
+@dataclass
+class EntityCreated:
+    """Dataclass to record 
+
+    Attributes:
+    name: The name of this entity.
+    id: The unique immutable ID for this entity.
+    parent_id: parent id of the entity
+    node_type: Type of Node
+    content_type: Content type of folder annotated,
+    created_on: The date this entity was created.
+    created_by: The ID of the user that created this entity.
+    is_public: True to indicate if this entity is public.
+    """
+
+    name: str
+    id: int
+    parent_id: int
+    node_type: str
+    content_type: str
+    created_on: str
+    created_by: str
+    is_public: bool
+
+
+@dag(**dag_config)
+def datasets_or_projects_created_7_days() -> None:
+    """Execute a query on Snowflake and report the results to a Synapse table."""
+
+    @task
+    def get_datasets_projects_created_7_days(**context) -> List[EntityCreated]:
+        """Execute the query on Snowflake and return the results."""
+        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        ctx = snow_hook.get_conn()
+        cs = ctx.cursor()
+        query = f"""
+        SELECT 
+            name,
+            id,
+            parent_id,
+            node_type,
+            annotations:annotations:contentType:value as content_type,
+            created_on,
+            created_by,
+            is_public,
+        FROM 
+            synapse_data_warehouse.synapse.node_latest
+        WHERE 
+            (
+                node_type IN ('dataset', 'project') 
+                OR 
+                (content_type LIKE '%dataset%' AND content_type IS NOT NULL)
+            )
+        AND 
+            (
+                created_on >= CURRENT_TIMESTAMP - INTERVAL '7 days' 
+            )
+        ORDER BY created_on;
+        """
+        print(query)
+        cs.execute(query)
+        created_entity_df = cs.fetch_pandas_all()
+
+        entity_created = []
+        for _, row in created_entity_df.iterrows():
+            entity_created.append(
+                EntityCreated(
+                    name=row["NAME"],
+                    id=row["ID"],
+                    node_type=row["NODE_TYPE"],
+                    parent_id=row["PARENT_ID"],
+                    content_type=row["CONTENT_TYPE"],
+                    created_on=row["CREATED_ON"],
+                    created_by=row["CREATED_BY"],
+                    is_public=row["IS_PUBLIC"]
+                )
+            )
+        return entity_created
+
+    @task
+    def push_results_to_synapse_table(entity_created: List[EntityCreated], **context) -> None:
+        """Push the results to a Synapse table."""
+        data = []
+        today = date.today()
+        for row in entity_created:
+            data.append(
+                [
+                    row.name,
+                    row.id,
+                    row.node_type,
+                    row.parent_id,
+                    row.content_type,
+                    row.created_on,
+                    row.created_by,
+                    row.is_public,
+                    today,
+                ]
+            )
+
+        syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
+        syn_hook.client.store(
+            synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
+        )
+
+    get_entity_created = get_datasets_projects_created_7_days()
+    push_to_synapse_table = push_results_to_synapse_table(entity_created=get_entity_created)
+
+    get_entity_created >> push_to_synapse_table
+
+
+datasets_or_projects_created_7_days()

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -168,14 +168,14 @@ def datasets_or_projects_created_7_days() -> None:
                 data_type = row.content_type
             else:
                 data_type = row.node_type
-            message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|{row.user_name}>, Public: {row.is_public})\n\n"
+            message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|{row.full_name}>, Public: {row.is_public})\n\n"
         return message
 
     @task
     def post_slack_messages(message: str) -> bool:
         """Post the top downloads to the slack channel."""
         client = WebClient(token=Variable.get("SLACK_DPE_TEAM_BOT_TOKEN"))
-        result = client.chat_postMessage(channel="hotdrops", text=message)
+        result = client.chat_postMessage(channel="hotdrop_test", text=message)
         print(f"Result of posting to slack: [{result}]")
         return result is not None
 
@@ -216,13 +216,13 @@ def datasets_or_projects_created_7_days() -> None:
     entity_created = get_datasets_projects_created_7_days()
     check = check_backfill()
     stop = stop_dag()
-    push_to_synapse_table = push_results_to_synapse_table(entity_created=entity_created)
+    # push_to_synapse_table = push_results_to_synapse_table(entity_created=entity_created)
     slack_message = generate_slack_message(entity_created=entity_created)
-    post_to_slack = post_slack_messages(message=slack_message)
+    # post_to_slack = post_slack_messages(message=slack_message)
 
     entity_created >> check >> [stop, slack_message]
-    slack_message >> post_to_slack
-    entity_created >> push_to_synapse_table
+    # slack_message >> post_to_slack
+    # entity_created >> push_to_synapse_table
 
 
 datasets_or_projects_created_7_days()

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -64,7 +64,7 @@ class EntityCreated:
         node_type: Type of Node
         content_type: Content type of folder annotated,
         created_on: The date this entity was created.
-        full_name: Full name of the user that created this entity
+        user_name_full_name: Full name of the user that created this entity. If first name or last name is null, use user name
         created_by: The ID of the user that created this entity.
         is_public: True to indicate if this entity is public.
     """
@@ -75,7 +75,7 @@ class EntityCreated:
     node_type: str
     content_type: str
     created_on: str
-    full_name: str
+    user_name_full_name: str
     created_by: str
     is_public: bool
 
@@ -118,7 +118,7 @@ def datasets_or_projects_created_7_days() -> None:
             ARRAY_TO_STRING(annotations:annotations:contentType:value, ', ') as content_type,
             TO_DATE(n.created_on) as entity_created_date,
             created_by,
-            CONCAT(first_name,' ',last_name) AS full_name,
+            CASE WHEN last_name IS NULL OR first_name is NULL THEN user_name ELSE CONCAT(first_name,' ',last_name)END as user_name_full_name,
             is_public,
         FROM 
             synapse_data_warehouse.synapse.node_latest as n
@@ -152,7 +152,7 @@ def datasets_or_projects_created_7_days() -> None:
                     parent_id=row["PARENT_ID"],
                     content_type=row["CONTENT_TYPE"],
                     created_on=row["ENTITY_CREATED_DATE"],
-                    full_name=row["FULL_NAME"],
+                    user_name_full_name=row["USER_NAME_FULL_NAME"],
                     created_by=row["CREATED_BY"],
                     is_public=row["IS_PUBLIC"],
                 )
@@ -168,7 +168,7 @@ def datasets_or_projects_created_7_days() -> None:
                 data_type = row.content_type
             else:
                 data_type = row.node_type
-            message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|{row.full_name}>, Public: {row.is_public})\n\n"
+            message += f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|{row.user_name_full_name}>, Public: {row.is_public})\n\n"
         return message
 
     @task

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -35,7 +35,7 @@ SYNAPSE_RESULTS_TABLE = "syn64919238"
 
 @dataclass
 class EntityCreated:
-    """Dataclass to record 
+    """Dataclass to record
 
     Attributes:
     name: The name of this entity.
@@ -107,11 +107,11 @@ def datasets_or_projects_created_7_days() -> None:
                     content_type=row["CONTENT_TYPE"],
                     created_on=row["ENTITY_CREATED_DATE"],
                     created_by=row["CREATED_BY"],
-                    is_public=row["IS_PUBLIC"]
+                    is_public=row["IS_PUBLIC"],
                 )
             )
         return entity_created
-    
+
     @task
     def generate_slack_message(entity_created: List[EntityCreated], **context) -> str:
         """Generate the message to be posted to the slack channel."""
@@ -125,7 +125,7 @@ def datasets_or_projects_created_7_days() -> None:
         return message
 
     @task
-    def post_slack_messages(message:str) -> bool:
+    def post_slack_messages(message: str) -> bool:
         """Post the top downloads to the slack channel."""
         client = WebClient(token=Variable.get("SLACK_DPE_TEAM_BOT_TOKEN"))
         result = client.chat_postMessage(channel="hotdrop_test", text=message)
@@ -133,7 +133,9 @@ def datasets_or_projects_created_7_days() -> None:
         return result is not None
 
     @task
-    def push_results_to_synapse_table(entity_created: List[EntityCreated], **context) -> None:
+    def push_results_to_synapse_table(
+        entity_created: List[EntityCreated], **context
+    ) -> None:
         """Push the results to a Synapse table."""
         data = []
         today = date.today()
@@ -158,13 +160,13 @@ def datasets_or_projects_created_7_days() -> None:
         )
 
     entity_created = get_datasets_projects_created_7_days()
-    # push_to_synapse_table = push_results_to_synapse_table(entity_created=entity_created)
+    push_to_synapse_table = push_results_to_synapse_table(entity_created=entity_created)
     slack_message = generate_slack_message(entity_created=entity_created)
     post_to_slack = post_slack_messages(message=slack_message)
 
     entity_created >> slack_message
     slack_message >> post_to_slack
-    # entity_created >> push_to_synapse_table
+    entity_created >> push_to_synapse_table
 
 
 datasets_or_projects_created_7_days()

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -39,14 +39,14 @@ class EntityCreated:
     """Dataclass to record
 
     Attributes:
-    name: The name of this entity.
-    id: The unique immutable ID for this entity.
-    parent_id: parent id of the entity
-    node_type: Type of Node
-    content_type: Content type of folder annotated,
-    created_on: The date this entity was created.
-    created_by: The ID of the user that created this entity.
-    is_public: True to indicate if this entity is public.
+        name: The name of this entity.
+        id: The unique immutable ID for this entity.
+        parent_id: parent id of the entity
+        node_type: Type of Node
+        content_type: Content type of folder annotated,
+        created_on: The date this entity was created.
+        created_by: The ID of the user that created this entity.
+        is_public: True to indicate if this entity is public.
     """
 
     name: str

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -5,8 +5,8 @@ See ORCA-301 for more context.
 A Note on the `backfill` functionality:
 In addition to the fact that this DAG pulls data from the day prior to the provided date, there is an extra wrinkle when using the `backfill` functionality.
 In the Synapse table UI, data is displayed at the local datetime of the user, but the Snowflake query is performed at UTC time. So, if we take into account both of these time differences
-for someone living in North America, you will need to provide a `backfill_date` 2 days after the date that the data is missing in the Synapse table. For example,
-if data is missing for "2025-01-03", `backfill_date` will need to be set to "2025-01-05". Additionally, be sure to set `backfill` to `true` or the DAG will run normally and post
+for someone living in North America, you will need to provide a `backfill_date_time` 2 days after the date that the data is missing in the Synapse table. For example,
+if data is missing for "2025-01-03", `backfill_date_time` will need to be set to "2025-01-05". Additionally, be sure to set `backfill` to `true` or the DAG will run normally and post
 the results to Slack.
 
 DAG Parameters:

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -5,8 +5,8 @@ See ORCA-301 for more context.
 A Note on the `backfill` functionality:
 In addition to the fact that this DAG pulls data from the day prior to the provided date, there is an extra wrinkle when using the `backfill` functionality.
 In the Synapse table UI, data is displayed at the local datetime of the user, but the Snowflake query is performed at UTC time. So, if we take into account both of these time differences
-for someone living in North America, you will need to provide a `backfill_date_time` 2 days after the date that the data is missing in the Synapse table. For example,
-if data is missing for "2025-01-03", `backfill_date_time` will need to be set to "2025-01-05". Additionally, be sure to set `backfill` to `true` or the DAG will run normally and post
+for someone living in North America, you will need to provide a `backfill_date` 2 days after the date that the data is missing in the Synapse table. For example,
+if data is missing for "2025-01-03", `backfill_date` will need to be set to "2025-01-05". Additionally, be sure to set `backfill` to `true` or the DAG will run normally and post
 the results to Slack.
 
 DAG Parameters:


### PR DESCRIPTION
## Problem
As requested in SNOW-228, a Synapse table needs to be created to store information about projects and datasets created in the past seven days. Additionally, this includes folders that have the annotation "content type = dataset".

## Solution
A DAG was implemented along with a Synapse table to store the retrieved data.
Slack message can be sent to a slack channel

## Test
A table can be successfully updated using airflow: https://www.synapse.org/Synapse:syn64919238/tables/
Made sure that slack messages can be sent to "hotdrop_test" channel