### PR TITLE
[DPE-1234] Ensure that we are pulling the md5 from the right version from history

### DIFF
--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -370,6 +370,7 @@ def dataset_to_croissant() -> None:
                     ) AS file_object
                 FROM files_belonging_to_dataset
             ),
+            -- TODO: Annotation selection must be version dependent, however, the different versions of the annotations are not available in a non-deduplicated table
             distinct_annotation_keys AS (
                 SELECT DATASET_SYNAPSE_ID, ARRAY_AGG(annotation_key) as annotation_keys FROM (
                     SELECT


### PR DESCRIPTION
# **Problem:**

- A Synapse Dataset points to both a specific Synapse ID, and a specific version_number. The code are written was pulling the MD5 from the latest version, which would not always be the MD5 of the file we are referencing in the dataset.

# **Solution:**

- Filter in the `version_history` column for a matching `versionNumber` in the JSON array. This will support pulling the MD5 for the correct record.

# **Testing:**

- I verified that I could run the query on a dataset which had entries pointing to the non-latest version. I verified the correct MD5 was pulled.
- I verified that I could still run the DAG after I ran the changes in github codespaces


# **Future considerations:**

- Since datasets point to specific versioned file entities, the annotations which are available also change by version. The `node_latest` snowflake dynamic table does not show anything except for the latest state of the entities annotations. Further changes would be needed if we need to point at the specific versions annotations.
