### PR TITLE
[snow-237] use key-pair authentication when connecting to snowflake

### DIFF
--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -15,7 +15,6 @@ DAG Parameters:
 - `backfill`: Whether to backfill the data. Defaults to `False`.
 - `backfill_date_time`: The date time to backfill the data from. in UTC time zone. Will be ignored if `backfill` is `False`.
 """
-
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import List
@@ -29,7 +28,7 @@ from orca.services.synapse import SynapseHook
 from slack_sdk import WebClient
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_raw_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date_time": Param(
         datetime.now(timezone.utc).strftime("%Y-%m-%d  %H:%M:%S"), type="string"
@@ -99,7 +98,10 @@ def datasets_or_projects_created_7_days() -> None:
     @task
     def get_datasets_projects_created_7_days(**context) -> List[EntityCreated]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(
+        # Set up SnowflakeHook dynamically
+        context["params"]["snowflake_developer_raw_conn"]
+        )
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
 

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -98,10 +98,7 @@ def datasets_or_projects_created_7_days() -> None:
     @task
     def get_datasets_projects_created_7_days(**context) -> List[EntityCreated]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(
-        # Set up SnowflakeHook dynamically
-        context["params"]["snowflake_developer_service_conn"]
-        )
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
 

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -9,7 +9,7 @@ if data is missing for "2025-01-03", `backfill_date` will need to be set to "202
 the results to Slack.
 
 DAG Parameters:
-- `snowflake_conn_id`: The connection ID for the Snowflake connection.
+- `snowflake_developer_service_conn`: A JSON-formatted string containing the connection details required to authenticate and connect to Snowflake.
 - `synapse_conn_id`: The connection ID for the Synapse connection.
 - 'current_date_time': The current date time in UTC timezone
 - `backfill`: Whether to backfill the data. Defaults to `False`.
@@ -28,7 +28,7 @@ from orca.services.synapse import SynapseHook
 from slack_sdk import WebClient
 
 dag_params = {
-    "snowflake_developer_raw_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date_time": Param(
         datetime.now(timezone.utc).strftime("%Y-%m-%d  %H:%M:%S"), type="string"
@@ -100,7 +100,7 @@ def datasets_or_projects_created_7_days() -> None:
         """Execute the query on Snowflake and return the results."""
         snow_hook = SnowflakeHook(
         # Set up SnowflakeHook dynamically
-        context["params"]["snowflake_developer_raw_conn"]
+        context["params"]["snowflake_developer_service_conn"]
         )
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()


### PR DESCRIPTION
# **Problem:**
Currently we have username and password hardcoded as a URI string like the following:
```
export AIRFLOW_CONN_SNOWFLAKE_DEFAULT='snowflake://user:password@/db-schema?
account=account&database=snow-db&region=us-east&warehouse=snow-warehouse'
```
But we need to switch to [key pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth) for enhance security. 

# **Solution:**
- Stored new secret as: airflow/connections/SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN in AWS secret manager
- Configured DAG to communicate with snowflake using the new secret

## Lesson learned: 
* wrap the string as 64 characters each line
* Make sure that the secret has header: `-----BEGIN ENCRYPTED PRIVATE KEY-----` and `-----END ENCRYPTED PRIVATE KEY-----` just like the documentation [here](https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-key). **Note that other headers won't work for encrypted key!** After formatting the key properly, save it in a .pem file. 
* Ensure that your secret can be properly loaded using snowflake CLI. 
Configure your config file like this: 
```
[connections]
[connections.developer]
account = "<account name>"
user = "<user name>"
authenticator = "SNOWFLAKE_JWT"
private_key_path = "path to .pem file"
private_key_file_pwd = "<pass phrase>"
```
And you should be able to verify the access by running:  
```
snow --config-file connections.toml connection test --debug
```
You should get a 200 response in the console. 

* after making sure that the private key is working for snowflake, you would then take the private key to snowflake secret manager. There are two ways to configure the secrets based on the [documentation](https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html#configuring-the-connection). After some trials and errors, I found out that I had to turn the key to a single line that could fit into the json: 
```
def single_liner():
    with open("mykey.pem", "r") as f:
        lines = f.read().splitlines()

    single_line = "\\n".join(lines)
    print(single_line)
```
Also even though base on the documentation, all these parameters are "optional", but you have to specify: 
- warehouse
- role
- account name
- private key 
- authenticator 
- remove region (or region as "us-east" doesn't work) so better to be removed. 

# **Test:**
Make sure that the DAG could run using the new way to authenticate. 