### PR TITLE
[DPE-1275] Upgrade apache airflow instance to 2.10.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG BASE_IMAGE=apache/airflow:2.9.3-python3.10
+ARG BASE_IMAGE=apache/airflow:2.10.5-python3.10
 FROM $BASE_IMAGE
 
 RUN pip install --upgrade pip
 
-RUN pip install apache-airflow[amazon,celery,snowflake]==2.9.3 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.10.txt"
+RUN pip install apache-airflow[amazon,celery,snowflake]==2.10.5 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.10.txt"
 
 COPY requirements-airflow.txt /tmp/requirements-airflow.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-airflow.txt

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -7,7 +7,7 @@ source venv/bin/activate
 # Upgrade pip to latest version
 pip install --upgrade pip
 # Install airflow with constraints
-pip install apache-airflow==2.9.3 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.10.txt"
+pip install apache-airflow==2.10.5 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.10.txt"
 # Install other dependencies
 pip install -r requirements-airflow.txt
 # Install dev dependencies

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -1,8 +1,8 @@
-apache-airflow-providers-amazon ~=8.25
-apache-airflow-providers-celery >=3.7
-apache-airflow-providers-snowflake ~=5.6
-snowflake-connector-python ~=3.11
-py-orca[all] == 1.4.0
+apache-airflow-providers-amazon ~=9.2.0
+apache-airflow-providers-celery >=3.10.0
+apache-airflow-providers-snowflake ~=6.0.0
+snowflake-connector-python ~=3.13.2
+py-orca[all] == 1.5.0
 pandas <3.0.0
 slack-sdk >=3.27
-pendulum<3.0.0
+pendulum~=3.0.0


### PR DESCRIPTION
# **Problem:**

- There are some issues we are seeing with the apache airflow scheduler not running at expected times or consistenly

# **Solution:**

- Upgrade apache airflow to the latest version to take into account all bug fixes

# **Testing:**

- Once a new image is created we will be deploying the new images out to the dev k8s cluster
- I verified that I could build the instance in a codespaces environment and run a DAG:

![image](https://github.com/user-attachments/assets/8bcd0f2f-f2c3-483f-9de2-8fe8871e4ef0)
