### PR TITLE
[snow-270] Update all snowflake authentication DAGs

### DIFF
--- a/dags/portal-data-to-snowflake-dag.py
+++ b/dags/portal-data-to-snowflake-dag.py
@@ -9,8 +9,8 @@ from orca.services.synapse import SynapseHook
 from snowflake.connector.pandas_tools import write_pandas
 
 dag_params = {
-    "snowflake_conn_id": Param(
-        "SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"
+    "snowflake_developer_service_conn": Param(
+        "SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"
     ),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
 }
@@ -64,7 +64,7 @@ def portal_data_to_snowflake():
 
     @task
     def lead_portal_data_to_snowflake(portal_data, **context):
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         # For now we will overwrite tables each time
         for portal_name, info in portal_data.items():
             write_pandas(

--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -14,7 +14,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from orca.services.synapse import SynapseHook
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     # date string with the format: YYYY-MM-DD including the month that we want to run the queries for
     "month_to_run": Param((date.today() - relativedelta(months=1)).strftime("%Y-%m-%d"), type="string"),
@@ -59,7 +59,7 @@ def synapse_by_the_numbers_past_month() -> None:
     @task
     def get_synapse_monthly_metrics(**context) -> List[DownloadMetric]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(context["params"]["SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
         query = f"""

--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -59,7 +59,7 @@ def synapse_by_the_numbers_past_month() -> None:
     @task
     def get_synapse_monthly_metrics(**context) -> List[DownloadMetric]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN"])
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
         query = f"""

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -21,7 +21,7 @@ integration for Apache Airflow. OTEL support is officially added in 2.10.0, but 
 that we also upgrade the production Airflow server.
 
 DAG Parameters:
-- `snowflake_conn_id`: The connection ID for the Snowflake connection.
+- `snowflake_developer_service_conn`: A JSON-formatted string containing the connection details required to authenticate and connect to Snowflake.
 - `synapse_conn_id`: The connection ID for the Synapse connection.
 - `dataset_collections`: The dataset collections to query for datasets.
 - `push_results_to_s3`: A boolean to indicate if the results should be pushed to S3.
@@ -57,7 +57,7 @@ from opentelemetry.trace.propagation.tracecontext import \
     TraceContextTextMapPropagator
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "dataset_collections": Param(["syn50913342"], type="array"),
     "push_results_to_s3": Param(True, type="boolean"),
@@ -254,7 +254,7 @@ def dataset_to_croissant() -> None:
                 node_type = 'datasetcollection'
                 AND id = {dataset_collection_without_syn}
             """
-            snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+            snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
             ctx = snow_hook.get_conn()
             cs = ctx.cursor()
 
@@ -501,7 +501,7 @@ def dataset_to_croissant() -> None:
             FROM
                 croissant_metadata;
             """
-            snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+            snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
             ctx = snow_hook.get_conn()
             cs = ctx.cursor()
 

--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -14,7 +14,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from orca.services.synapse import SynapseHook
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
 }
@@ -61,7 +61,7 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
     @task
     def get_all_time_downloads_from_snowflake(**context) -> List[DownloadMetric]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
         query = f"""

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -13,7 +13,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from orca.services.synapse import SynapseHook
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
 }
 
@@ -59,7 +59,7 @@ def top_public_synapse_projects_all_time_from_snowflake() -> None:
     @task
     def get_all_time_downloads_from_snowflake(**context) -> List[DownloadMetric]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
         query = f"""

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -10,7 +10,7 @@ if data is missing for "2025-01-03", `backfill_date` will need to be set to "202
 the results to Slack.
 
 DAG Parameters:
-- `snowflake_conn_id`: The connection ID for the Snowflake connection.
+- `snowflake_developer_service_conn`: A JSON-formatted string containing the connection details required to authenticate and connect to Snowflake.
 - `synapse_conn_id`: The connection ID for the Synapse connection.
 - `hours_time_delta`: The number of hours to subtract from the current date to get the date for the query. Defaults to `24`.
 - `backfill`: Whether to backfill the data. Defaults to `False`.
@@ -30,7 +30,7 @@ from orca.services.synapse import SynapseHook
 from slack_sdk import WebClient
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     # hours_time_delta is the number of hours to subtract from the current date to get the date for the query
     "hours_time_delta": Param("24", type="string"),
@@ -87,7 +87,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
     @task
     def get_top_downloads_from_snowflake(**context) -> List[DownloadMetric]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
 

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -28,7 +28,7 @@ SYNAPSE_RESULTS_TABLE = "syn61597055"
 SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 dag_params = {
-    "snowflake_conn_id": Param("SNOWFLAKE_SYSADMIN_PORTAL_RAW_CONN", type="string"),
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
     "month_to_run": Param((date.today() - relativedelta(months=1)).strftime("%Y-%m-%d"), type="string")
@@ -83,7 +83,7 @@ def trending_projects_snapshot() -> None:
     @task
     def get_trending_project_snapshot(**context) -> List[SnapshotMetrics]:
         """Execute the query on Snowflake and return the results."""
-        snow_hook = SnowflakeHook(context["params"]["snowflake_conn_id"])
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
         ctx = snow_hook.get_conn()
         cs = ctx.cursor()
         query = f"""


### PR DESCRIPTION
# **Problem:**
Related to: https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/80

# **Solution:**
Update all the DAGs to use new connection when connecting to snowflake. 

# **Test**
I tested the following DAGs locally
* `portal_data_to_snowflake`: there's a step that pushes data to snowflake. I commented out that part of the code and only tested the connection by: 
```
    @task
    def lead_portal_data_to_snowflake(portal_data, **context):
        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
        print('getting credentials', snow_hook.get_conn())
```
But came across an error: 
```
  File "/opt/airflow/dags/portal-data-to-snowflake-dag.py", line 50, in get_portal_data_from_synapse
    portal_df = portal.asDataFrame()
  File "/home/airflow/.local/lib/python3.10/site-packages/synapseclient/table.py", line 2497, in asDataFrame
    except pd.parser.CParserError:
AttributeError: module 'pandas' has no attribute 'parser'

```
* `synapse_by_the_numbers_past_month`: tested top_downloads with new snowflake connection and it worked
* `dataset_to_croissant`: set push to s3 to False and tested all the other step, especially `query_snowflake_and_push_croissant_file` and it all worked. 
* `top_public_synapse_projects_30_days_from_snowflake`: tested `get_all_time_downloads_from_snowflake` step  and it worked 
* `top_public_synapse_projects_all_time_from_snowflake` tested `get_all_time_downloads_from_snowflake` step and it worked
* `top_public_synapse_projects_from_snowflake`: tested `get_top_downloads_from_snowflake` step and the step of generating a slack message. They all worked
* `trending_projects_snapshot`: tested `trending_projects_snapshot` without pushing to synapse and it worked. 