### PR TITLE
[DPE-1275] Move to Synapse API, Automate deletion of S3 objects/Synapse Rows, File/Dataset versioning corrections

### DIFF
--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -487,6 +487,12 @@ def extract_s3_objects_to_delete(bucket_objects: List[str], dataset_collections_
         dataset_collections_to_consider_for_deletion: The dataset collections to
             consider for deletion. This is passed in from the
             `dataset_collections_for_cleanup` DAG parameter.
+        combined_dataset_collection_and_datasets: The combined list of dataset IDs,
+            dataset collections, and dataset versions to use to determine which
+            datasets to delete.
+
+    Returns:
+        The list of objects to delete from the S3 bucket.
     """
     objects_to_delete = []
 

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -8,7 +8,7 @@ This DAG interacts with a few different services to accomplish the following:
 - (S3, Authenticated) For each dataset push an object a public S3 bucket in the `org-sagebase-dpe-prod` AWS account
 - (Synapse, Authenticated) For each dataset query a Synapse table which contains links to the S3 object
 - (Synapse, Authenticated) Delete rows from the Synapse table which are not in a dataset collection
-- (Synapse, Aauthenticated) For each dataset push a link for the S3 object to a Synapse table via the authenticated Synapse client
+- (Synapse, Authenticated) For each dataset push a link for the S3 object to a Synapse table via the authenticated Synapse client
 - (S3, Authenticated) Delete S3 objects from the S3 bucket which are not in a dataset collection
 
 

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -304,6 +304,7 @@ def construct_distribution_section_for_files(files_attached_to_dataset: List[Fil
     for file in files_attached_to_dataset:
         file: File = file
         if not file.file_handle or not file.file_handle.content_md5:
+            # TODO: Handle for cases where a file may be included twice within the dataset
             files_to_find_md5_in_snowflake[int(file.id.replace(
                 "syn", ""))] = file.version_number
 

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -26,6 +26,10 @@ DAG Parameters:
 - `dataset_collections`: The dataset collections to query for datasets.
 - `push_results_to_s3`: A boolean to indicate if the results should be pushed to S3.
                         When set to `False`, the results will be printed to the logs.
+- `delete_out_of_date_from_s3`: A boolean to indicate if the old files should be 
+                        deleted from S3. When set to `False`, the old files will not 
+                        be deleted, but a message will be logged to indicate that
+                        the files will be deleted when set to `True`.
 - `aws_conn_id`: The connection ID for the AWS connection. Used to authenticate with S3.
 """
 

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -717,7 +717,7 @@ def execute_push_to_synapse(push_to_synapse: bool, dataset: Entity, dataset_id: 
 
 @dag(**dag_config)
 def dataset_to_croissant() -> None:
-    """Execute a query on Snowflake and report the results to a Synapse table.
+    """Execute api calls to Synapse, and queries on snowflake to convert datasets into croissant JSON-LD files.
 
 
     DAG Parameters:

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -2,7 +2,7 @@ apache-airflow-providers-amazon ~=9.2.0
 apache-airflow-providers-celery >=3.10.0
 apache-airflow-providers-snowflake ~=6.0.0
 snowflake-connector-python ~=3.13.2
-py-orca[all] == 1.5.0
+py-orca[all] == 1.5.1
 pandas <3.0.0
 slack-sdk >=3.27
 pendulum~=3.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
-opentelemetry-exporter-otlp ==1.21.0 # make the synapseclient and apache-airflow play nice
-synapseclient ~=4.1.1
-fs-synapse ~=2.0
+synapseclient >=4.7,<5.0
+fs-synapse >=2.0,<3.0
 s3fs ~=2023.5
 metaflow ~=2.9
 boto3 >=1.7.0,<2.0


### PR DESCRIPTION
# **Problem:**

- We were using the Snowflake datawarehouse to source information in order to build this process. Per [these guidelines](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4043079690/Data+Warehouse+Usage+Guidelines+policies) we want to limit usage of the warehouse.
- Deleting S3 objects that were no longer present in the dataset collections was a manual process
- We did not capture version information for the file entities
- We did not persist S3 object links back to a Synapse table to use for downstream processes

# **Solution:**

- Moving all (Except MD5 retrieval) reads to occur via unauthenticated/anonymous Synapse APIs
- Adding logic to delete out S3 objects which are no longer present in the dataset collections given.
- Adding version information for the croissant file
- Adding support to push s3 object links to a Synapse table
- Support deleting rows out of the Synapse table which should no longer show

# **Testing:**

- I verified that I could run this DAG in github codespaces with all params set to True
- Data is pushed to this (INTERNAL TO SAGE FOR NOW) table: https://www.synapse.org/Synapse:syn65903895/tables/


TODO: 

- [x] Naming convention changes for the croissant spec file are ok
- [x] The JSON LD file contains all expected changes
- [x] Push the links to the S3 objects back into a Synapse table that has columns for: Synapse ID of the Dataset collection, Synapse ID of the Dataset, Version of the Dataset, Link to the S3 object
