### PR TITLE
[SYNPY-1587] SQS Polling POC DAG

### DIFF
--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -19,6 +19,11 @@ dag_params = {
     "aws_conn_id": Param(
         "AWS_DNT_DEV_SQS_CONN", type="string", description="AWS connection ID to use"
     ),
+    "region_name": Param(
+        "us-east-1",
+        type="string",
+        description="AWS region where the SQS queue is located",
+    ),
     "sqs_queue_url": Param(
         "https://sqs.us-east-1.amazonaws.com/631692904429/dev-synapse-sqs-create-queue",
         type="string",
@@ -73,7 +78,10 @@ def sqs_polling_synapse_notification_dag():
         Poll the SQS queue for messages.
         This task will return only when messages are found or when it times out.
         """
-        sqs_hook = SqsHook(aws_conn_id=context["params"]["aws_conn_id"])
+        sqs_hook = SqsHook(
+            aws_conn_id=context["params"]["aws_conn_id"],
+            region_name=context["params"]["region_name"],
+        )
         queue_url = context["params"]["sqs_queue_url"]
         max_messages = context["params"]["max_messages"]
         wait_time_seconds = context["params"]["wait_time_seconds"]

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -59,7 +59,8 @@ dag_params = {
 
 
 @dag(
-    schedule_interval="*/15 * * * *",  # Run every 15 minutes
+    # Disabled schedule for testing
+    # schedule_interval="*/15 * * * *",  # Run every 15 minutes
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={
@@ -95,7 +96,7 @@ def sqs_polling_synapse_notification_dag():
         )
 
         if "Messages" in response and len(response["Messages"]) > 0:
-            # Consume messages from the queue
+            # Delete messages from the queue
             entries = [
                 {"Id": msg["MessageId"], "ReceiptHandle": msg["ReceiptHandle"]}
                 for msg in response["Messages"]

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -10,7 +10,7 @@ from typing import List, Dict, Any, Union
 
 from airflow.decorators import dag, task
 from airflow.models.param import Param
-from airflow.providers.amazon.aws.hooks.sqs import SQSHook
+from airflow.providers.amazon.aws.hooks.sqs import SqsHook
 
 from orca.services.synapse import SynapseHook
 
@@ -73,7 +73,7 @@ def sqs_polling_synapse_notification_dag():
         Poll the SQS queue for messages.
         This task will return only when messages are found or when it times out.
         """
-        sqs_hook = SQSHook(aws_conn_id=context["params"]["aws_conn_id"])
+        sqs_hook = SqsHook(aws_conn_id=context["params"]["aws_conn_id"])
         queue_url = context["params"]["sqs_queue_url"]
         max_messages = context["params"]["max_messages"]
         wait_time_seconds = context["params"]["wait_time_seconds"]

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -73,11 +73,10 @@ def sqs_polling_synapse_notification_dag():
     DAG that polls an SQS queue and sends notifications to Synapse users about received messages.
     """
 
-    @task.sensor(poke_interval=60, timeout=300, mode="poke")
+    @task
     def poll_sqs_queue(**context) -> List[Dict[str, Any]]:
         """
         Poll the SQS queue for messages.
-        This task will return only when messages are found or when it times out.
         """
         sqs_hook = SqsHook(
             aws_conn_id=context["params"]["aws_conn_id"],
@@ -130,10 +129,6 @@ def sqs_polling_synapse_notification_dag():
                 "id": message["MessageId"],
                 "body": formatted_message,
             }
-
-            # Add any message attributes if they exist
-            if "MessageAttributes" in message:
-                processed_message["attributes"] = message["MessageAttributes"]
 
             processed_messages.append(processed_message)
 

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -1,8 +1,9 @@
 """
 This DAG demonstrates polling an SQS queue and sending notifications to Synapse users.
-1. Set up a sensor to poll an SQS queue
-2. Process the messages from the queue
+1. Poll an SQS queue
+2. Process the messages from the queue (Consume messages by deleting them)
 3. Send notifications to Synapse users about the received messages
+If there are no new messages, the DAG will stop and send no messages.
 """
 
 import json
@@ -59,8 +60,7 @@ dag_params = {
 
 
 @dag(
-    # Disabled schedule for testing
-    # schedule_interval="*/15 * * * *",  # Run every 15 minutes
+    schedule_interval="*/15 * * * *",  # Run every 15 minutes
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={
@@ -186,7 +186,8 @@ def sqs_polling_synapse_notification_dag():
     send_notification = send_synapse_notification(processed_msgs)
 
     # Set up the branch task dependencies
-    branch >> [processed_msgs, stop_dag()] >> send_notification
+    branch >> [processed_msgs, stop_dag()]
+    processed_msgs >> send_notification
 
 
 # Instantiate the DAG

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -95,7 +95,7 @@ def sqs_polling_synapse_notification_dag():
         )
 
         if "Messages" in response and len(response["Messages"]) > 0:
-            # Delete messages from the queue
+            # Consume messages from the queue
             entries = [
                 {"Id": msg["MessageId"], "ReceiptHandle": msg["ReceiptHandle"]}
                 for msg in response["Messages"]

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -191,7 +191,7 @@ def sqs_polling_synapse_notification_dag():
     branch = check_for_messages(messages)
     processed_msgs = process_messages(messages)
     send_notification = send_synapse_notification(processed_msgs)
-    delete_messages = delete_sqs_messages(messages, processed_msgs)
+    delete_messages = delete_sqs_messages(messages)
 
     # Set up the branch task dependencies
     branch >> [processed_msgs, stop_dag()]

--- a/dags/synapse-webhook-poc-dag.py
+++ b/dags/synapse-webhook-poc-dag.py
@@ -1,0 +1,166 @@
+"""
+This DAG demonstrates polling an SQS queue and sending notifications to Synapse users.
+1. Set up a sensor to poll an SQS queue
+2. Process the messages from the queue
+3. Send notifications to Synapse users about the received messages
+"""
+
+from datetime import datetime
+from typing import List, Dict, Any, Union
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+from airflow.providers.amazon.aws.hooks.sqs import SQSHook
+
+from orca.services.synapse import SynapseHook
+
+# Default parameters for the DAG
+dag_params = {
+    "aws_conn_id": Param(
+        "AWS_DNT_DEV_SQS_CONN", type="string", description="AWS connection ID to use"
+    ),
+    "sqs_queue_url": Param(
+        "https://sqs.us-east-1.amazonaws.com/631692904429/dev-synapse-sqs-create-queue",
+        type="string",
+        description="URL of the SQS queue to poll",
+    ),
+    "synapse_conn_id": Param(
+        "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN",
+        type="string",
+        description="Synapse connection ID to use",
+    ),
+    "user_list": Param(
+        "bwmac",
+        type="string",
+        description="Comma-separated list of Synapse users to notify",
+    ),
+    "message_subject": Param(
+        "New SQS Message Notification",
+        type="string",
+        description="Subject of the Synapse notification",
+    ),
+    "max_messages": Param(
+        10,
+        type="integer",
+        description="Maximum number of messages to retrieve per polling",
+    ),
+    "wait_time_seconds": Param(
+        20,
+        type="integer",
+        description="The time in seconds to wait for receiving messages",
+    ),
+}
+
+
+@dag(
+    schedule_interval="*/15 * * * *",  # Run every 15 minutes
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args={
+        "retries": 2,
+    },
+    tags=["sqs", "synapse", "notifications"],
+    params=dag_params,
+)
+def sqs_polling_synapse_notification_dag():
+    """
+    DAG that polls an SQS queue and sends notifications to Synapse users about received messages.
+    """
+
+    @task.sensor(poke_interval=60, timeout=300, mode="poke")
+    def poll_sqs_queue(**context) -> List[Dict[str, Any]]:
+        """
+        Poll the SQS queue for messages.
+        This task will return only when messages are found or when it times out.
+        """
+        sqs_hook = SQSHook(aws_conn_id=context["params"]["aws_conn_id"])
+        queue_url = context["params"]["sqs_queue_url"]
+        max_messages = context["params"]["max_messages"]
+        wait_time_seconds = context["params"]["wait_time_seconds"]
+
+        response = sqs_hook.get_conn().receive_message(
+            QueueUrl=queue_url,
+            MaxNumberOfMessages=max_messages,
+            WaitTimeSeconds=wait_time_seconds,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+        )
+
+        if "Messages" in response and len(response["Messages"]) > 0:
+            # Delete messages from the queue
+            entries = [
+                {"Id": msg["MessageId"], "ReceiptHandle": msg["ReceiptHandle"]}
+                for msg in response["Messages"]
+            ]
+
+            sqs_hook.get_conn().delete_message_batch(
+                QueueUrl=queue_url, Entries=entries
+            )
+
+            return response["Messages"]
+        return []
+
+    @task
+    def process_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Process the SQS messages before sending notifications.
+        This could include data transformation, filtering, etc.
+        """
+        if not messages:
+            return []
+
+        processed_messages = []
+        for message in messages:
+            # Here you could transform or process the message as needed
+            # For this example, we'll just pass the message body through
+            processed_message = {
+                "id": message["MessageId"],
+                "body": message["Body"],
+            }
+
+            # Add any message attributes if they exist
+            if "MessageAttributes" in message:
+                processed_message["attributes"] = message["MessageAttributes"]
+
+            processed_messages.append(processed_message)
+
+        return processed_messages
+
+    @task
+    def send_synapse_notification(
+        processed_messages: List[Dict[str, Any]], **context
+    ) -> Union[int, None]:
+        """
+        Send notification to Synapse users about the received messages.
+        """
+        if not processed_messages:
+            return
+
+        user_list = context["params"]["user_list"].split(",")
+        subject = context["params"]["message_subject"]
+
+        # Construct message body from the processed messages
+        message_body = "The following messages were received from the SQS queue:\n\n"
+        for i, msg in enumerate(processed_messages, 1):
+            message_body += f"Message {i}:\n"
+            message_body += f"ID: {msg['id']}\n"
+            message_body += f"Body: {msg['body']}\n\n"
+
+        # Send notification to Synapse users
+        hook = SynapseHook(context["params"]["synapse_conn_id"])
+        id_list = [
+            hook.client.getUserProfile(user).get("ownerId") for user in user_list
+        ]
+
+        hook.client.sendMessage(id_list, subject, message_body)
+
+        return len(processed_messages)
+
+    # Define task dependencies
+    messages = poll_sqs_queue()
+    processed_msgs = process_messages(messages)
+    send_synapse_notification(processed_msgs)
+
+
+# Instantiate the DAG
+sqs_polling_synapse_notification_dag()


### PR DESCRIPTION
# **Problem:**

We needed an example DAG that to demonstrate polling an SQS queue which contains messages about entity creation within a parent entity.

# **Solution:**

As part of [SYNPY-1587](https://sagebionetworks.jira.com/browse/SYNPY-1587), I created this DAG as a demonstration of how one could automatically poll an SQS queue for messages about entities that have been created within a Synapse parent entity (Folder or Project). The SQS queue was created using Terraform modules that can be viewed in this `eks-stack` [PR](https://github.com/Sage-Bionetworks-Workflows/eks-stack/pull/62). The Synapse Webhook itself was created using this Python [script](https://gist.github.com/BWMac/fc406be9e4a2aee39c659465e9c9f3e7).

I needed to give Airflow access to SQS in the `dnt-dev` AWS account so I created the `airflow-sqs-access` IAM user with the AmazonSQSFullAccess IAM role attached, and an AWS Secrets connection string `airflow/connections/AWS_DNT_DEV_SQS_CONN` in the `dpe-prod` account. The SQS infrastructure would need to be deployed in `dpe-prod` and similar access would need to be granted if we wanted to use this fully in production.

# **Testing:**

Ensured that there was a message in the SQS queue and ran the DAG. I received this email:
![image](https://github.com/user-attachments/assets/6aa2c85a-9374-4456-a376-03f8a2f17b0c)

# **Notes:**

This DAG should remain paused in production because it is just an example and is not automating a required business process.


[SYNPY-1587]: https://sagebionetworks.jira.com/browse/SYNPY-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ