### PR TITLE
[DPE-1288] Move `jsonata` to requirements-airflow.txt

### DIFF
--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -6,3 +6,4 @@ py-orca[all] == 1.5.2
 pandas <3.0.0
 slack-sdk >=3.27
 pendulum~=3.0.0
+jsonata-python ~=0.5.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ fs-synapse >=2.0,<3.0
 s3fs ~=2023.5
 metaflow ~=2.9
 boto3 >=1.7.0,<2.0
-jsonata-python ~=0.5.3


### PR DESCRIPTION
# **Problem:**

I added a new dependency to `requirements-dev.txt` instead of `requirements-airflow.txt` by mistake. As a result the new DAG implemented in #89 is failing to be imported.

![image](https://github.com/user-attachments/assets/44b3cb5a-c072-4f7c-b75c-8d1d0103b30e)

# **Solution:**

Move the dependency to `requirements-airflow.txt`.

# **Testing:**

N/A

**Edit:** This issue actually happened because we need to publish a new version of the docker image and update `eks-stack` with the new version number, but this change should still be merged since `jsonata-python` is not a development-specific package