### PR TITLE
[DPE-1312] Adds Release Container Pipeline

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  ghcr-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=ref,event=branch
+            type=sha
+            latest
+      - name: Publish Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: |
+            TARBALL_PATH=${{ needs.prepare.outputs.tarball-path }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - DPE-1312-adds-release-pipeline
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - DPE-1312-adds-release-pipeline
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    branches:
+      - DPE-1312-adds-release-pipeline
   release:
     types: [published]
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,3 @@ RUN pip install apache-airflow[amazon,celery,snowflake]==2.10.5 --constraint "ht
 
 COPY requirements-airflow.txt /tmp/requirements-airflow.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-airflow.txt
-
-COPY requirements-dev.txt /tmp/requirements-dev.txt
-RUN pip install --no-cache-dir -r /tmp/requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -63,17 +63,23 @@ source venv/bin/activate
 ```
 This will create a virtual environment with Python version 3.10 and all needed dependencies and activate it. Before running, be sure to have Python 3.10 or `pyenv` installed on your machine.
 
-## Building a new docker image
+## Releases
 
-At the moment this is a manual process to build and push a new `orca-recipes` container
-to GHCR. In order to accomplish this task:
+To release a new version of the `orca-recipes` container to GHCR:
 
-1. Create a new github codespaces environment detailed above.
-2. Build the new image with the specific version you want: `docker build -t ghcr.io/sage-bionetworks-workflows/orca-recipes:0.0.0 .`
-3. Ensure you are logged into the GHCR: `echo $GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin`
-   1. Replace `$GITHUB_TOKEN` and `USERNAME` with the correct values
-4. Push the image to GHCR for your version: `docker push ghcr.io/sage-bionetworks-workflows/orca-recipes:0.0.0`
+1. Create a new GitHub Release in the repository
+   - Go to the repository's "Releases" page
+   - Click "Create a new release"
+   - Create a new tag with the version number (e.g., `1.0.0`)
+   - Add release notes
+   - Click "Publish release"
 
+The GitHub Actions workflow will automatically:
+- Build the Docker image
+- Tag it with the release version
+- Push it to GHCR
+
+The `latest` tag will automatically be updated to point to the latest release.
 
 ## Contributing a Challenge DAG
 

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -7,3 +7,4 @@ pandas <3.0.0
 slack-sdk >=3.27
 pendulum~=3.0.0
 jsonata-python ~=0.5.3
+boto3 >=1.7.0,<2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,3 @@
-synapseclient >=4.8,<5.0
 fs-synapse >=2.0,<3.0
 s3fs ~=2023.5
 metaflow ~=2.9
-boto3 >=1.7.0,<2.0


### PR DESCRIPTION
# **Problem:**

Our production Airflow deployment depends on a versioned Docker container being built from this repository, but at present we do not have a release workflow to version the repository and publish a container to GHCR.

# **Solution:**

Implement a workflow that publishes a versioned container. The `latest` tag will be applied when a release is minted, `eks-stack` can be updated to pull the latest release and then it will no longer need to be updated for future releases. New releases only need to be made when a change is implemented to the repository that impacts the Dockerfile, or anything that the Dockerfile references such as dependencies in order for our production deployment to pick up the change.

I also adjusted the Dockerfile and dependencies so that we are only installing from `requirements-airflow.txt` for our production image. `requirements-dev.txt` should only be used for local development or for running any of our local metaflow workflows.

# **Testing:**

Manually ran the pipeline by minting a test release to produce this [container](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pkgs/container/orca-recipes/413830922?tag=0.0.0).
