### PR TITLE
[DPE-1288] ALS-KP DAG XCOM Bug

### DIFF
--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -221,7 +221,7 @@ def als_kp_dataset_dag():
     @task
     def create_datasets(
         transformed_items: List[Dict[str, Any]], **context
-    ) -> DatasetCollection:
+    ) -> str:
         """Create Synapse datasets and collection.
 
         This task:
@@ -236,7 +236,7 @@ def als_kp_dataset_dag():
             **context: Airflow task context containing DAG parameters
 
         Returns:
-            DatasetCollection: The created and stored dataset collection
+            stt: The Synapse ID of the created and stored dataset collection
         """
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         synapse_client = syn_hook.client
@@ -275,11 +275,11 @@ def als_kp_dataset_dag():
             dataset_collection.add_item(dataset)
 
         dataset_collection = dataset_collection.store(synapse_client=synapse_client)
-        return dataset_collection
+        return dataset_collection.id
 
     @task
     def update_annotations(
-        dataset_collection: DatasetCollection,
+        dataset_collection_id: str,
         transformed_items: List[Dict[str, Any]],
         **context,
     ) -> None:
@@ -303,6 +303,8 @@ def als_kp_dataset_dag():
         """
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         synapse_client = syn_hook.client
+
+        dataset_collection = DatasetCollection(id=dataset_collection_id).get()
 
         dataset_ids = [item.id for item in dataset_collection.items]
 
@@ -380,8 +382,8 @@ def als_kp_dataset_dag():
     # Define task dependencies
     data = fetch_cpath_data()
     transformed_items = transform_data(data)
-    dataset_collection = create_datasets(transformed_items)
-    update_annotations(dataset_collection, transformed_items)
+    dataset_collection_id = create_datasets(transformed_items)
+    update_annotations(dataset_collection_id, transformed_items)
 
 
 als_kp_dataset_dag()

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -161,7 +161,7 @@ def transform_with_jsonata(
 
 
 @dag(**dag_config)
-def als_kp_dataset_dag_test():
+def als_kp_dataset_dag():
     @task
     def fetch_cpath_data(**context) -> Dict[str, Any]:
         """Fetch data from C-Path API using auth token from Airflow Variables.
@@ -386,4 +386,4 @@ def als_kp_dataset_dag_test():
     update_annotations(dataset_collection_id, transformed_items)
 
 
-als_kp_dataset_dag_test()
+als_kp_dataset_dag()

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -236,7 +236,7 @@ def als_kp_dataset_dag():
             **context: Airflow task context containing DAG parameters
 
         Returns:
-            stt: The Synapse ID of the created and stored dataset collection
+            str: The Synapse ID of the created and stored dataset collection
         """
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         synapse_client = syn_hook.client
@@ -297,7 +297,7 @@ def als_kp_dataset_dag():
            - The comment includes timestamp, changed columns, and dataset count
 
         Arguments:
-            dataset_collection: The dataset collection to update
+            dataset_collection_id: The ID of the dataset collection to update
             transformed_items: List of transformed items containing new annotations
             **context: Airflow task context containing DAG parameters
         """

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -161,7 +161,7 @@ def transform_with_jsonata(
 
 
 @dag(**dag_config)
-def als_kp_dataset_dag():
+def als_kp_dataset_dag_test():
     @task
     def fetch_cpath_data(**context) -> Dict[str, Any]:
         """Fetch data from C-Path API using auth token from Airflow Variables.
@@ -386,4 +386,4 @@ def als_kp_dataset_dag():
     update_annotations(dataset_collection_id, transformed_items)
 
 
-als_kp_dataset_dag()
+als_kp_dataset_dag_test()


### PR DESCRIPTION
# **Problem:**

Even though the DAG worked when I tested it in our development environment, it failed in production with this error:
```
[2025-05-15, 13:42:08 UTC] {taskinstance.py:3313} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 274, in _run_raw_task
    TaskInstance._execute_task_with_callbacks(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 3117, in _execute_task_with_callbacks
    task_orig = self.render_templates(context=context, jinja_env=jinja_env)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 3540, in render_templates
    original_task.render_template_fields(context, jinja_env)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/baseoperator.py", line 1442, in render_template_fields
    self._do_render_template_fields(self, self.template_fields, context, jinja_env, set())
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/abstractoperator.py", line 775, in _do_render_template_fields
    rendered_content = self.render_template(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/template/templater.py", line 179, in render_template
    return tuple(self.render_template(element, context, jinja_env, oids) for element in value)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/template/templater.py", line 179, in <genexpr>
    return tuple(self.render_template(element, context, jinja_env, oids) for element in value)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/template/templater.py", line 175, in render_template
    return value.resolve(context, include_xcom=True)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 97, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/xcom_arg.py", line 450, in resolve
    result = ti.xcom_pull(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 94, in wrapper
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 3698, in xcom_pull
    return _xcom_pull(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/api_internal/internal_api_call.py", line 166, in wrapper
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/session.py", line 94, in wrapper
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 633, in _xcom_pull
    return XCom.deserialize_value(first)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/xcom.py", line 720, in deserialize_value
    return BaseXCom._deserialize_value(result, False)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/xcom.py", line 715, in _deserialize_value
    return json.loads(result.value.decode("UTF-8"), cls=XComDecoder, object_hook=object_hook)
  File "/usr/local/lib/python3.10/json/__init__.py", line 359, in loads
    return cls(**kw).decode(s)
  File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.10/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/json.py", line 118, in object_hook
    return deserialize(dct)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/serialization/serde.py", line 281, in deserialize
    return cls(**deserialize(value))
  File "<string>", line 26, in __init__
  File "/home/airflow/.local/lib/python3.10/site-packages/synapseclient/models/dataset.py", line 2223, in __post_init__
    self.columns = self._convert_columns_to_ordered_dict(columns=self.columns)
  File "/home/airflow/.local/lib/python3.10/site-packages/synapseclient/models/mixins/table_components.py", line 1154, in _convert_columns_to_ordered_dict
    if column.name:
AttributeError: 'dict' object has no attribute 'name'
```
It appears that XCOM is not happy with my passing a `DatasetCollection` object between tasks and things go wrong when it parses it. I'm unsure why this only happens in our production deployment, but this is really not following best practices to be honest so I probably shouldn't have done this in the first place.

# **Solution:**

Pass the ID of the `DatasetCollection` instead and `get` it where needed.

# **Testing:**

I did test this in a development codespace, but I can't think of a way to test this in our production environment prior to merging since the airflow containers have read-only filesystems. If anyone has ideas I'm open to them. Otherwise I will just test after merging and readdress the issue if needed.
