### PR TITLE
[DPE-1267] update schedule_interval for challenge DAGs

### DIFF
--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -50,7 +50,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     
     # Start with default configuration
     dag_config = {
-        "schedule_interval": "*/1 * * * *",
+        "schedule_interval": "*/3 * * * *",
         "start_date": datetime(2024, 4, 9),
         "catchup": False,
         "default_args": {"retries": 2},


### PR DESCRIPTION
# **Problem:**

Sometimes the challenge DAG won't get to the step that changes the submission status to "EVALUATION_IN_PROGRESS" fast enough, before another cycle is triggered, causing duplicate evaluations of the same submission:

<img width="419" alt="image" src="https://github.com/user-attachments/assets/e5a03441-fec5-41ee-828f-b767bb912d29" />

# **Solution:**

Update the `schedule_interval` so the DAG runs once every 3 mins instead of every minute.

# **Testing:**

N/A