### PR TITLE
[DPE-1267] Minimize risk of duplicate evaluations for the same Challenge submission

### DIFF
--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -77,7 +77,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
 
     return dag_config
 
-def get_processed_submission_ids(dag_id: str, n_runs: int = 5) -> set:
+def get_processed_submission_ids(dag_id: str, n_runs: int = 6) -> set:
     """
     Queries the last `n_runs` of successful or running DagRuns for `dag_id`,
     and pulls their XComs for `get_new_submissions`, returning a set of all submission IDs seen.

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -208,8 +208,8 @@ def create_challenge_dag(challenge_name: str, config: dict):
         tower_run_id = launch_workflow(manifest_path, run_uuid)
         monitor = monitor_workflow(tower_run_id)
 
-        # Fail fast if ``bucket_name`` is invalid
-        verify >> submissions >> submissions_updated >> [stop, manifest_path]
+        # Fail fast if ``bucket_name`` is invalid, after getting submissions
+        submissions >> submissions_updated >> verify >> [stop, manifest_path]
         manifest_path >> tower_run_id >> monitor
 
     return challenge_dag()

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -116,8 +116,8 @@ def get_processed_submission_ids(dag_id: str, n_runs: int = 5) -> set:
 
             # Query the metadata DB (``xcom_pull``) to retrieve the submission IDs...
             # By default, pulling the XComs for `get_new_submissions`
-            # will return the submission IDs, since they are the return values
-            prev_subs = task_run.xcom_pull()
+            # will return the submission ID list, since that is the return value
+            prev_subs = task_run.xcom_pull(task_ids=task_id)
 
             print(f"Previous submission IDs: {prev_subs}")
 


### PR DESCRIPTION
# **Problem:**

@vpchung mentions she is still experiencing duplicate e-mails sometimes, which means the DAGs are not updating the submission statuses fast enough.

# **Solution:**

Following [conversation](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/98#issuecomment-2891749444) with @BWMac, our workaround solution will involve retrieving submission IDs for the last N submissions to filter them out in submission retrievals for following runs.

- [x] Introduce `get_processed_submission_ids` which gets previous submission IDs already processed
- [x] Create a [Jira ticket](https://sagebionetworks.jira.com/browse/DPE-1351) to figure out the root cause of the repeated evaluations

# **Testing:**

### BEFORE

Previous runs of the task 2 DAG for Olfactory resulted in duplicate evaluations for the same submission

<img width="423" alt="image" src="https://github.com/user-attachments/assets/2fe170e0-2e41-45a5-bb2d-eaa62393963a" />

### AFTER

Here is the log for a task run that does not find any previous submission IDs from the last 5 runs, which is correct, based on the graph. The log for `get_new_submissions` makes sense. No new submission IDs for the past 5 runs (including the current one).

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/5385b8da-1c9f-4fa9-a25a-a02d4ae2da9e" />

After updating my submission back to RECEIVED, I'm still not able to pick it up in new DAG runs because it's been previously collected, which is the behavior we want:

<img width="1483" alt="image" src="https://github.com/user-attachments/assets/b5121dc3-0094-4674-bd79-3fcbfeeb5fe4" />

After 4 runs with no submission IDs collected, the DAG forgets about the submission and it gets picked up as a brand new one:

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/fc7f7611-cc45-4d43-a24b-8174162e4042" />

I'll bump this up to `n_runs = 6` so it actually checks for the last 5 completed/running submissions.