### PR TITLE
[dpe-1357]: Restrict the annotation update and snapshot evaluation to datasets from the Critical Path Institute

### DIFF
--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -306,13 +306,12 @@ def als_kp_dataset_dag():
             synapse_client=synapse_client
         )
 
-        dataset_ids = [item.id for item in dataset_collection.items]
-
         # Get current data before update
         current_data = dataset_collection.query(
-            query=f"SELECT * from {dataset_collection.id}",
+            query=f"SELECT * from {dataset_collection.id} where source='Critical Path Institute'",
             synapse_client=synapse_client,
         )
+        dataset_ids = list(current_data["id"])
         # Prepare and apply new data
         annotation_data = pd.DataFrame(
             {
@@ -351,7 +350,7 @@ def als_kp_dataset_dag():
 
         # Get data after update
         updated_data = dataset_collection.query(
-            query=f"SELECT * from {dataset_collection.id}",
+            query=f"SELECT * from {dataset_collection.id} where source='Critical Path Institute'",
             synapse_client=synapse_client,
         )
 


### PR DESCRIPTION
# **Problem:**
Got an error when running the DAG: 
```
[2025-05-30, 22:54:09 UTC] {taskinstance.py:3313} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 768, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 734, in _execute_callable
    return ExecutionCallableRunner(
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/baseoperator.py", line 424, in wrapper
    return func(self, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/decorators/base.py", line 266, in execute
    return_value = super().execute(context)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/models/baseoperator.py", line 424, in wrapper
    return func(self, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 238, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 256, in execute_callable
    return runner.run(*self.op_args, **self.op_kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
  File "/opt/airflow/dags/als-kp-dataset-dag.py", line 319, in update_annotations
    annotation_data = pd.DataFrame(
  File "/home/airflow/.local/lib/python3.10/site-packages/pandas/core/frame.py", line 733, in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)
  File "/home/airflow/.local/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 503, in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)
  File "/home/airflow/.local/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 114, in arrays_to_mgr
    index = _extract_index(arrays)
  File "/home/airflow/.local/lib/python3.10/site-packages/pandas/core/internals/construction.py", line 677, in _extract_index
    raise ValueError("All arrays must be of the same length")
ValueError: All arrays must be of the same length
```
This error happened at this line here:  `annotation_data = pd.DataFrame(` in the `update_annotations` step. This is because there are new dataset collections being manually added, and when we pulled the existing dataset collections there using `dataset_ids = [item.id for item in dataset_collection.items]`, the amount of datasets are greater than what the C-Path API returned. 

# **Solution:**
Only consider datasets from the Critical Path Institute when updating annotations and determining whether a snapshot is needed.

# **Testing:**
It worked now locally using my Airflow DAG. 
