### PR TITLE
[DPE-1314] Add 4 new programs to topcharts slack message

### DIFF
--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -38,7 +38,7 @@ dag_params = {
     # Example: '[{"file_view_id": "123456", "group_name": "Group A"},
     #           {"file_view_id": "789012", "group_name": "Group B"}]'
     "fileview_groups": Param(
-        '[{"file_view_id": "20446927", "group_name": "HTAN1"}]', type="string"),
+        '[{"file_view_id": "20446927", "group_name": "HTAN1"},{"file_view_id": "51489960", "group_name": "ELITE"},{"file_view_id": "16858331", "group_name": "NF-OSI"},{"file_view_id": "27210848", "group_name": "MC2"},{"file_view_id": "52794526", "group_name": "GENIE"}]', type="string"),
 }
 
 dag_config = {


### PR DESCRIPTION
# **Problem:**

- There are 4 new project groups to add to the topcharts slack message

# **Solution:**

- Add the new FileViews and project names to the array

# **Testing:**

- I verified in a codespaces environment that I could run this. I verified that data was returning back as ` DownloadMetric` object and would correct be filtered in the final slack message. For a date from last week:

```
[DownloadMetric(name='MC2', project='syn27210848', projects_with_downloads=1, total_projects=159, downloads_per_project=18, number_of_unique_users_downloaded=1, data_download_size=Decimal('168492598')), 
DownloadMetric(name='NF-OSI', project='syn16858331', projects_with_downloads=8, total_projects=288, downloads_per_project=509, number_of_unique_users_downloaded=8, data_download_size=Decimal('102157245105')), 
DownloadMetric(name='GENIE', project='syn52794526', projects_with_downloads=2, total_projects=2, downloads_per_project=350, number_of_unique_users_downloaded=9, data_download_size=Decimal('3802879160')), 
DownloadMetric(name='ELITE', project='syn51489960', projects_with_downloads=3, total_projects=6, downloads_per_project=107, number_of_unique_users_downloaded=6, data_download_size=Decimal('25975080')), 
DownloadMetric(name='HTAN1', project='syn20446927', projects_with_downloads=14, total_projects=17, downloads_per_project=1155, number_of_unique_users_downloaded=10, data_download_size=Decimal('433426645427'))]
```
