### PR TITLE
[DPE-1355]: updated data model and added source and url column 

### DIFF
--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -31,11 +31,11 @@ from airflow.models import Variable, Param
 dag_params = {
     "project_id": Param("syn64892175", type="string"),
     "mapping_url": Param(
-        "https://raw.githubusercontent.com/amp-als/data-model/dd0e476c3659c9b98977d567d0ddce01d5057639/mapping/cpath.jsonata",
+        "https://raw.githubusercontent.com/amp-als/data-model/410a429540a81a63846921ee77d6cf8e33ab6407/mapping/cpath.jsonata",
         type="string",
     ),
     "schema_url": Param(
-        "https://raw.githubusercontent.com/amp-als/data-model/dd0e476c3659c9b98977d567d0ddce01d5057639/json-schemas/Dataset.json",
+        "https://raw.githubusercontent.com/amp-als/data-model/410a429540a81a63846921ee77d6cf8e33ab6407/json-schemas/Dataset.json",
         type="string",
     ),
     "cpath_api_url": Param(
@@ -249,6 +249,8 @@ def als_kp_dataset_dag():
             Column(name="publisher", column_type=ColumnType.STRING, maximum_size=100),
             Column(name="species", column_type=ColumnType.STRING, maximum_size=100),
             Column(name="sameAs", column_type=ColumnType.STRING, maximum_size=100),
+            Column(name="source", column_type=ColumnType.STRING, maximum_size=100),
+            Column(name="url", column_type=ColumnType.STRING, maximum_size=100),
         ]
 
         dataset_collection = DatasetCollection(
@@ -334,6 +336,8 @@ def als_kp_dataset_dag():
                         "publisher",
                         "species",
                         "sameAs",
+                        "source",
+                        "url"
                     ]
                 },
             }


### PR DESCRIPTION
# **Problem:**
Currently, when we pull data from C-path, C-path returned the URL suffix of the data in a field called "code". See an example below from the "fetch data" step in the DAG: 
```
{'id': 1815, 'code': 'src_als_1002_2025_03_25', 'xxx': 'xxx'}
```
But this information is not exposed in the final dataset collection. 
After the PR [here]([Update model and mappings by anngvu · Pull Request #14 · amp-als/data-model](https://github.com/amp-als/data-model/pull/14)), we want to update the data model and add "source" and "url" as two additional columns in the dataset collection. 

# **Solution:**
* updated the data model url in the DAG and added two additional columns. 

# **Testing:**
The DAG works: 
<img width="924" alt="Screenshot 2025-06-05 at 1 05 35 PM" src="https://github.com/user-attachments/assets/f85934b6-584b-41d1-a0f4-519007e5520e" />

And I also could see dataset collection gets updated with "source" and "url" columns: https://www.synapse.org/Synapse:syn66496326/datasets/
<img width="405" alt="Screenshot 2025-06-05 at 1 06 50 PM" src="https://github.com/user-attachments/assets/d49baa3a-f0db-4f8f-9589-43b6f6d574c6" />

