### PR TITLE
[DPE-1398] Send slack messages when duplicates are found and remove automatic snapshots

### DIFF
--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -31,7 +31,7 @@ import time
 
 
 dag_params = {
-    "project_id": Param("syn68155335", type="string"),
+    "project_id": Param("syn64892175", type="string"),
     "mapping_url": Param(
         "https://raw.githubusercontent.com/amp-als/data-model/410a429540a81a63846921ee77d6cf8e33ab6407/mapping/cpath.jsonata",
         type="string",

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -454,7 +454,7 @@ def als_kp_dataset_dag():
 
         if len(dataset_ids) != len(annotations["title"]):
             raise ValueError(
-                f" There are {len(dataset_ids)} stored in dataset collection, but there are {len(annotations['title'])} datasets to update. "
+                f"There are {len(dataset_ids)} stored in dataset collection, but there are {len(annotations['title'])} datasets to update."
             )
 
         annotation_data = pd.DataFrame({"id": dataset_ids, **annotations})

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -343,7 +343,7 @@ def als_kp_dataset_dag():
             contents = f.read()
             content_json = json.loads(contents)
             datasets_to_ignore = content_json.get("ignore_cpath_identifier", [])
-        print("dataset identifiers to be ignored after human review: " datasets_to_ignore)
+        print("dataset identifiers to be ignored after human review: " + str(datasets_to_ignore))
         return datasets_to_ignore
 
     @task

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -313,7 +313,7 @@ def als_kp_dataset_dag():
         if not message:
             return
         client = WebClient(token=Variable.get("SLACK_DPE_TEAM_BOT_TOKEN"))
-        client.chat_postMessage(channel="test-amp-als-dataset-message", text=message)
+        client.chat_postMessage(channel="amp-als", text=message)
 
     @task
     def create_datasets(

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -381,7 +381,7 @@ def als_kp_dataset_dag():
         ).get(synapse_client=synapse_client)
 
         for item in transformed_items:
-            if item in duplicates and item["sameAs"] in ignored_datasets:
+            if item in duplicates or item["sameAs"] in ignored_datasets:
                 continue
             dataset_description = (
                 item["description"][:1000]

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -6,7 +6,7 @@ for the ALS Knowledge Portal. The DAG follows these steps:
 1. Fetch data from the C-Path API using an authentication token stored in Airflow Variables
 2. Transform the raw data using a JSONata mapping expression and validate against a JSON Schema
 3. Find duplicates in the new C-Path data and send a message to AMP-ALS slack channel if duplicates are found. 
-4. Retrieve datasets that need to be ignored after human validation from a JSON file
+4. Data managers in AMP-ALS update the JSON file. The pipeline then reads this file to retrieve datasets that should be ignored following human validation.
 5. Create or update Synapse Datasets for each item in the transformed data, excluding duplicates and datasets marked to be ignored after manual review.
 6. Update the Dataset Collection to include all valid datasets, excluding duplicates and manually ignored datasets.
 7. Create or update annotations for each dataset in the collection

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -286,7 +286,7 @@ def als_kp_dataset_dag():
         return message
 
     @task
-    def post_slack_messages(message: str) -> bool:
+    def post_slack_messages(message: str):
         """Post the duplicated datasets to the slack channel."""
         if not message:
             return

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -5,10 +5,10 @@ for the ALS Knowledge Portal. The DAG follows these steps:
 
 1. Fetch data from the C-Path API using an authentication token stored in Airflow Variables
 2. Transform the raw data using a JSONata mapping expression and validate against a JSON Schema
-3. Create or update Synapse Datasets for each item in the transformed data
-4. Create or update a Dataset Collection containing all the datasets
-5. Create or update annotations for each dataset in the collection
-6. Create a new snapshot of the collection if any changes were detected
+3. Find duplicates in the new C-Path data and send a message to AMP-ALS slack channel if duplicates are found. 
+4. Create or update Synapse Datasets for each item in the transformed data
+5. Create or update a Dataset Collection containing all the datasets
+6. Create or update annotations for each dataset in the collection
 
 The DAG runs monthly and uses Airflow Variables for configuration.
 """

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -336,9 +336,7 @@ def als_kp_dataset_dag():
 
         # Find datasets that need to be ignored
         ignore_cpath_datasets_json = context["params"]["ignore_cpath_datasets"]
-        file = File(id=ignore_cpath_datasets_json, download_file=True).get(
-            synapse_client=synapse_client
-        )
+        file = File(id=ignore_cpath_datasets_json, download_file=True).get()
         with open(file.path, "r") as f:
             contents = f.read()
             content_json = json.loads(contents)
@@ -378,7 +376,7 @@ def als_kp_dataset_dag():
 
         dataset_collection = DatasetCollection(
             id=context["params"]["collection_id"]
-        ).get(synapse_client=synapse_client)
+        ).get()
 
         for item in transformed_items:
             if item in duplicates or item["sameAs"] in ignored_datasets:
@@ -445,12 +443,13 @@ def als_kp_dataset_dag():
         annotations = {key: [] for key in fields}
 
         for item in transformed_items:
-            if item not in duplicates and item["sameAs"] not in ignored_datasets:
-                for key in fields:
-                    value = item[key]
-                    if isinstance(value, list):
-                        value = ", ".join(value)
-                    annotations[key].append(value)
+            if item in duplicates or item["sameAs"] in ignored_datasets:
+                continue
+            for key in fields:
+                value = item[key]
+                if isinstance(value, list):
+                    value = ", ".join(value)
+                annotations[key].append(value)
 
         if len(dataset_ids) != len(annotations["title"]):
             raise ValueError(
@@ -465,7 +464,6 @@ def als_kp_dataset_dag():
             primary_keys=["id"],
             dry_run=False,
             wait_for_eventually_consistent_view=True,
-            synapse_client=synapse_client,
         )
 
     # Define task dependencies

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -272,7 +272,7 @@ def als_kp_dataset_dag():
                     seen[title] = item
                 else:
                     # found duplicates, add both the first one if it does not already exist and this one
-                    if seen[title] not in duplicates: 
+                    if seen[title] not in duplicates:
                         duplicates.append(seen[title])
                     duplicates.append(item)
         print("Found duplicated datasets:", duplicates)
@@ -342,7 +342,10 @@ def als_kp_dataset_dag():
             contents = f.read()
             content_json = json.loads(contents)
             datasets_to_ignore = content_json.get("ignore_cpath_identifier", [])
-        print("dataset identifiers to be ignored after human review: " + str(datasets_to_ignore))
+        print(
+            "dataset identifiers to be ignored after human review: "
+            + str(datasets_to_ignore)
+        )
         return datasets_to_ignore
 
     @task

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -271,9 +271,10 @@ def als_kp_dataset_dag():
                 if title not in seen:
                     seen[title] = item
                 else:
-                    # found duplicates, add both the first one and this one
+                    # found duplicates, add both the first one if it does not already exist and this one
+                    if seen[title] not in duplicates: 
+                        duplicates.append(seen[title])
                     duplicates.append(item)
-                    duplicates.append(seen[title])
         print("Found duplicated datasets:", duplicates)
         return duplicates
 

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -43,8 +43,7 @@ dag_params = {
     "cpath_api_url": Param(
         "https://fair.dap.c-path.org/api/collections/als-kp/datasets", type="string"
     ),
-    "collection_name": Param("test-collection", type="string"),
-    "collection_description": Param("test dataset collection", type="string"),
+    "collection_id": Param("syn66496326", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
 }
 
@@ -243,9 +242,8 @@ def als_kp_dataset_dag():
 
         # Get current datasets
         dataset_collection = DatasetCollection(
-            name=context["params"]["collection_name"],
-            parent_id=context["params"]["project_id"],
-        ).get()
+            id=context["params"]["collection_id"]
+        ).get(synapse_client=synapse_client)
         current_data = dataset_collection.query(
             query=f"SELECT * from {dataset_collection.id} where publisher='Critical Path Institute'",
             synapse_client=synapse_client,
@@ -324,12 +322,11 @@ def als_kp_dataset_dag():
         synapse_client = syn_hook.client
 
         dataset_collection = DatasetCollection(
-            name=context["params"]["collection_name"],
-            parent_id=context["params"]["project_id"],
-        ).get()
+            id=context["params"]["collection_id"]
+        ).get(synapse_client=synapse_client)
 
         for item in transformed_items:
-            if item in duplicates: 
+            if item in duplicates:
                 continue
             dataset_description = (
                 item["description"][:1000]

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -21,13 +21,12 @@ import pandas as pd
 from jsonata import jsonata
 from jsonschema import validate, ValidationError
 
-from synapseclient.models import Dataset, DatasetCollection, Column, ColumnType
+from synapseclient.models import Dataset, DatasetCollection
 from orca.services.synapse import SynapseHook
 
 from airflow.decorators import task, dag
 from airflow.models import Variable, Param
 from slack_sdk import WebClient
-import time
 
 
 dag_params = {


### PR DESCRIPTION
# **Problem (AC):**
Per discussion with the AMP-ALS team, we want to: 
- Have a human-in-the-loop to validate datasets before creating a snapshot
- Stop changing dataset collection schema 
- Send a Slack message to the channel if duplicates are found
- Provide better error handling when the number of stored datasets does not match the number of annotations to update.

# **Solution:**
- Provide a separate step to detect duplicates and send Slack messages
   - The two datasets are considered duplicates if they have the same title (See Jira comment [here](https://sagebionetworks.jira.com/browse/DPE-1398?focusedCommentId=259869))
- Remove automatic snapshots 
- Improve error handling when the number of stored datasets does not match the number of annotations to update.
- Use a separate JSON file to track validation results from a human. 

# **Testing:**
- Ensure that the DAG is working as expected using test dataset collection:  https://www.synapse.org/Synapse:syn68582286/datasets/
- Ensure that the DAG is working using a test slack channel: # test-amp-als-dataset-message

# Flow chart: 

<img width="500" height="3000" alt="Untitled diagram _ Mermaid Chart-2025-07-21-190747" src="https://github.com/user-attachments/assets/85cd39a7-9420-44f2-9bb5-91f7d7f28929" />
