### PR TITLE
[DPE-1409] Introduce final round DAGs for Olfactory challenge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,8 @@ Modify everything in `<>` and remove the `<>` when complete:
   key: "<10days/my_challenge>"
   dag_config:
     schedule_interval: "*/1 * * * *"
-    start_date: "2024-04-09T00:00:00"
+    start_date: "<YYYY>-<MM>-<DD>T<HH>:<MM>:<SS>+00:00" # Will be converted to a UTC datetime object
+    end_date: "<YYYY>-<MM>-<DD>T<HH>:<MM>:<SS>+00:00" # Will be converted to a UTC datetime object
     catchup: false
     default_args:
       retries: 2
@@ -161,7 +162,8 @@ See below for a list of parameters and their descriptions:
 1. `key`: The S3 key prefix (or folder path) under which the submissions manifest file is uploaded for a challenge DAG run. At runtime, a unique run-specific UUID is appended to this key to ensure that files are uniquely identified and organized. Since this folder path lives in a scratch bucket, you can leverage one of the folders that are configured to delete stale objects based on a certain number of days ([see here](https://sagebionetworks.jira.com/wiki/spaces/WF/pages/2191556616/Getting+Started+with+Nextflow+and+Seqera+Platform#Tower-Project-Breakdown) for more details). This will affect what value you put here. For example, **if you would like for your manifest file to live for 10 days, use `10days/my_project_folder`**.  
 1. `dag_config`: A nested dictionary containing additional DAG scheduling and runtime parameters:  
    * `schedule_interval`: A cron expression that determines how frequently the DAG is triggered.  
-   * `start_date`: An ISO-formatted date string that specifies when the DAG should start running. The DAG factory converts this to a Python datetime object.  
+   * `start_date`: An ISO 8601–formatted date-time string (e.g. `2025-07-16T08:00:00+02:00`) that tells the DAG factory when to begin scheduling runs. The trailing ±HH:MM UTC-offset makes the datetime timezone-aware, and the factory converts it into a Python datetime object in UTC.
+   * `end_date`: An ISO 8601–formatted date-time string (e.g. `2025-07-20T00:00:00-05:00`) that indicates when the DAG should stop scheduling new runs. Like start_date, it may include a ±HH:MM UTC-offset and is parsed by the factory into a timezone-aware Python datetime object in UTC.
    * `catchup`: A Boolean flag that indicates whether Airflow should run missed DAG runs (catch up) if the scheduler falls behind.  
    * `default_args`: Standard Airflow arguments for the DAG. For example, you can set the number of retries for tasks.  
    * `tags`: A list of tags for categorizing the DAG in the Airflow UI.

--- a/dags/challenge_configs.yaml
+++ b/dags/challenge_configs.yaml
@@ -30,6 +30,7 @@ olfactory-2025-task1:
   dag_config:
     schedule_interval: "*/3 * * * *"
     start_date: "2024-04-09T00:00:00"
+    end_date: "2025-07-21T00:00:00"
     catchup: false
     default_args:
       retries: 2
@@ -49,6 +50,47 @@ olfactory-2025-task2:
   dag_config:
     schedule_interval: "*/3 * * * *"
     start_date: "2024-04-09T00:00:00"
+    end_date: "2025-07-21T00:00:00"
+    catchup: false
+    default_args:
+      retries: 2
+    tags:
+      - "nextflow_tower"
+
+final-olfactory-2025-task1:
+  synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
+  aws_conn_id: "AWS_TOWER_PROD_S3_CONN"
+  revision: "TODO"
+  challenge_profile: "final_olfactory25_challenge_task1"
+  tower_conn_id: "OLFACTORY_CHALLENGE_PROJECT_TOWER_CONN"
+  tower_view_id: "syn68685416"
+  tower_compute_env_type: "spot"
+  bucket_name: "olfactory-challenge-project-tower-scratch"
+  key: "10days/final_olfactory_challenge_task1"
+  dag_config:
+    schedule_interval: "*/3 * * * *"
+    start_date: "2025-07-21T00:00:00"
+    end_date: "TODO"
+    catchup: false
+    default_args:
+      retries: 2
+    tags:
+      - "nextflow_tower"
+
+final-olfactory-2025-task2:
+  synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
+  aws_conn_id: "AWS_TOWER_PROD_S3_CONN"
+  revision: "TODO"
+  challenge_profile: "final_olfactory25_challenge_task2"
+  tower_conn_id: "OLFACTORY_CHALLENGE_PROJECT_TOWER_CONN"
+  tower_view_id: "syn68685447"
+  tower_compute_env_type: "spot"
+  bucket_name: "olfactory-challenge-project-tower-scratch"
+  key: "10days/final_olfactory_challenge_task2"
+  dag_config:
+    schedule_interval: "*/3 * * * *"
+    start_date: "2025-07-21T00:00:00"
+    end_date: "TODO"
     catchup: false
     default_args:
       retries: 2

--- a/dags/challenge_configs.yaml
+++ b/dags/challenge_configs.yaml
@@ -1,22 +1,3 @@
-pegs:
-  synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
-  aws_conn_id: "AWS_TOWER_PROD_S3_CONN"
-  revision: "558a3786e1610a0cb802e384ab082f696030809a" # Updated to the latest revision with new params.entry for PEGS
-  challenge_profile: "pegs_challenge_test"
-  tower_conn_id: "PEGS_CHALLENGE_PROJECT_TOWER_CONN"
-  tower_view_id: "syn58942525"
-  tower_compute_env_type: "spot"
-  bucket_name: "pegs-challenge-project-tower-scratch"
-  key: "10days/pegs_challenge"
-  dag_config:
-    schedule_interval: "*/1 * * * *"
-    start_date: "2024-04-09T00:00:00"  # ISO-format date string; will be converted in the DAG factory
-    catchup: false
-    default_args:
-      retries: 2
-    tags:
-      - "nextflow_tower"
-
 olfactory-2025-task1:
   synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
   aws_conn_id: "AWS_TOWER_PROD_S3_CONN"

--- a/dags/challenge_configs.yaml
+++ b/dags/challenge_configs.yaml
@@ -29,8 +29,8 @@ olfactory-2025-task1:
   key: "10days/olfactory_challenge_task1"
   dag_config:
     schedule_interval: "*/3 * * * *"
-    start_date: "2024-04-09T00:00:00"
-    end_date: "2025-07-21T00:00:00"
+    start_date: "2024-04-09T00:00:00+00:00"
+    end_date: "2025-07-21T00:00:00+00:00"
     catchup: false
     default_args:
       retries: 2
@@ -49,8 +49,8 @@ olfactory-2025-task2:
   key: "10days/olfactory_challenge_task2"
   dag_config:
     schedule_interval: "*/3 * * * *"
-    start_date: "2024-04-09T00:00:00"
-    end_date: "2025-07-21T00:00:00"
+    start_date: "2024-04-09T00:00:00+00:00"
+    end_date: "2025-07-21T00:00:00+00:00"
     catchup: false
     default_args:
       retries: 2
@@ -60,7 +60,7 @@ olfactory-2025-task2:
 final-olfactory-2025-task1:
   synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
   aws_conn_id: "AWS_TOWER_PROD_S3_CONN"
-  revision: "TODO"
+  revision: "7ffc708d945f98ab5cfd3a8d8b2cbad4696b4069"
   challenge_profile: "final_olfactory25_challenge_task1"
   tower_conn_id: "OLFACTORY_CHALLENGE_PROJECT_TOWER_CONN"
   tower_view_id: "syn68685416"
@@ -69,8 +69,8 @@ final-olfactory-2025-task1:
   key: "10days/final_olfactory_challenge_task1"
   dag_config:
     schedule_interval: "*/3 * * * *"
-    start_date: "2025-07-21T00:00:00"
-    end_date: "TODO"
+    start_date: "2025-07-21T00:00:00+00:00"
+    end_date: "2025-08-08T23:59:00+00:00"
     catchup: false
     default_args:
       retries: 2
@@ -80,7 +80,7 @@ final-olfactory-2025-task1:
 final-olfactory-2025-task2:
   synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
   aws_conn_id: "AWS_TOWER_PROD_S3_CONN"
-  revision: "TODO"
+  revision: "7ffc708d945f98ab5cfd3a8d8b2cbad4696b4069"
   challenge_profile: "final_olfactory25_challenge_task2"
   tower_conn_id: "OLFACTORY_CHALLENGE_PROJECT_TOWER_CONN"
   tower_view_id: "syn68685447"
@@ -89,8 +89,8 @@ final-olfactory-2025-task2:
   key: "10days/final_olfactory_challenge_task2"
   dag_config:
     schedule_interval: "*/3 * * * *"
-    start_date: "2025-07-21T00:00:00"
-    end_date: "TODO"
+    start_date: "2025-07-21T00:00:00+00:00"
+    end_date: "2025-08-08T23:59:00+00:00"
     catchup: false
     default_args:
       retries: 2

--- a/dags/challenge_configs.yaml
+++ b/dags/challenge_configs.yaml
@@ -50,7 +50,7 @@ final-olfactory-2025-task1:
   key: "10days/final_olfactory_challenge_task1"
   dag_config:
     schedule_interval: "*/3 * * * *"
-    start_date: "2025-07-21T00:00:00+00:00"
+    start_date: "2025-07-16T00:00:00+00:00"
     end_date: "2025-08-08T23:59:00+00:00"
     catchup: false
     default_args:
@@ -70,7 +70,7 @@ final-olfactory-2025-task2:
   key: "10days/final_olfactory_challenge_task2"
   dag_config:
     schedule_interval: "*/3 * * * *"
-    start_date: "2025-07-21T00:00:00+00:00"
+    start_date: "2025-07-16T00:00:00+00:00"
     end_date: "2025-08-08T23:59:00+00:00"
     catchup: false
     default_args:

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -155,6 +155,9 @@ def get_processed_submission_ids(dag_id: str, n_runs: int = 6) -> set:
         # Now retrieve the submission IDs for each run of `get_new_submissions` task
         for task_run in task_runs:
 
+            if task_run is None:
+                continue
+
             # Query the metadata DB (``xcom_pull``) to retrieve the submission IDs...
             # By default, pulling the XComs for `get_new_submissions`
             # will return the submission ID list, since that is the return value

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -2,7 +2,7 @@ import io
 import os
 import requests
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 import yaml
 import pandas as pd
 
@@ -33,6 +33,48 @@ def load_challenge_configs(url=CONFIG_URL):
 
     return yaml.safe_load(response.text)
 
+def enforce_utc_timezone(dag_config: dict):
+    """
+    Ensures that 'start_date' and 'end_date' in dag_config are timezone-aware datetimes in UTC.
+
+    Arguments:
+        dag_config: The DAG configurations
+
+    Raises:
+        ValueError if a value is naive (no timezone info) or not a valid datetime/string.
+    """
+
+    for param in ['start_date', 'end_date']:
+
+        if param in dag_config:
+
+            value = dag_config[param]
+
+            # Enforce string or datetime only
+            if isinstance(value, str):
+                try:
+                    dt = datetime.fromisoformat(value)
+                except ValueError as e:
+                    raise ValueError(
+                        f"{param} ('{value}') is not a valid ISO 8601 datetime string."
+                    ) from e
+            elif isinstance(value, datetime):
+                dt = value
+            else:
+                raise TypeError(
+                    f"{param} ('{value}') must be a string or datetime object."
+                )
+
+            # Enforce timezone-aware datetime object
+            if dt.tzinfo is None:
+                raise ValueError(
+                    f"{param}: '{value}' must include a timezone offset. If string, please add '+00:00' for UTC."
+                )
+
+            # Enforce UTC timezone
+            dag_config[param] = dt.astimezone(timezone.utc)
+        
+    
 def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> dict:
     """
     Return the DAG configuration for a challenge.
@@ -53,7 +95,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     # Start with default configuration
     dag_config = {
         "schedule_interval": "*/3 * * * *",
-        "start_date": datetime(2024, 4, 9),
+        "start_date": datetime(2024, 4, 9, tzinfo=timezone.utc),
         "catchup": False,
         "default_args": {"retries": 2},
         "tags": ["nextflow_tower"],
@@ -64,9 +106,8 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     if config.get('dag_config'):
         dag_config.update(config['dag_config'])
         
-        # Ensure start_date is a datetime object if provided
-        if 'start_date' in dag_config and isinstance(dag_config['start_date'], str):
-            dag_config['start_date'] = datetime.fromisoformat(dag_config['start_date'])
+        # Ensure start_date is a datetime object in UTC
+        enforce_utc_timezone(dag_config)
             
         # Ensure challenge name is in tags
         if 'tags' in dag_config:

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -106,7 +106,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     if config.get('dag_config'):
         dag_config.update(config['dag_config'])
         
-        # Ensure start_date is a datetime object in UTC
+        # Ensure start_date/end_date is a datetime object in UTC
         enforce_utc_timezone(dag_config)
             
         # Ensure challenge name is in tags


### PR DESCRIPTION
# **Problem:**

The Olfactory challenge will begin its final round on July 21st, and new DAGs need to be implemented for it.

# **Solution:**

- [x] Introduce new DAGs for the final round
- [x] Add an `end_date` parameter to the DAG configs to ensure the leaderboard round DAGs are paused
- [x] Enforce UTC time zone for the start/end date parameters, as highlighted in the challenge [timeline](https://www.synapse.org/Synapse:syn64743570/wiki/632391)
- [x] OOS: A detail was preventing jobs from running successfully: We check for the (default: 5) most recent DAG runs to pull the submissions that were evaluated (to prevent duplicates). For a fresh DAG, there are no prior DAG runs. The script needed to accommodate for this scenario.

# **Testing:**

✅ The DAG details confirm the updates to our `dag_config` in the challenge profile were received:

<img width="639" height="164" alt="image" src="https://github.com/user-attachments/assets/992bdce7-fe05-4157-80c2-2b51d3786bbc" />

<img width="642" height="50" alt="image" src="https://github.com/user-attachments/assets/4a3a8b4f-b18b-4f67-b346-b485ad5a1a60" />

✅ After I switched the `start_date` to today, the DAG started auto-running:

<img width="1099" height="510" alt="image" src="https://github.com/user-attachments/assets/736a61bf-a23b-4492-93e2-881676da10b3" />

✅ And lastly, a successful DAG run (after fixing the out-of-scope issue):

<img width="323" height="282" alt="image" src="https://github.com/user-attachments/assets/fdaa77cb-69f9-4d83-aac4-670e076d1275" />

