### PR TITLE
[DPE-1404, DPE-1403] Add new clinical mapping and run maf processing

### DIFF
--- a/local/iatlas/cbioportal_export/clinical_to_cbioportal.py
+++ b/local/iatlas/cbioportal_export/clinical_to_cbioportal.py
@@ -74,6 +74,8 @@ REQUIRED_OUTPUT_FILES = [
     "meta_clinical_sample.txt"
 ]
 
+LOG_FILE_NAME = "iatlas_cli_validation_log.txt"
+
 
 def remap_clinical_ids_to_paper_ids(input_df: pd.DataFrame) -> pd.DataFrame:
     """Remaps the clinical sample and patient id attributes to use the
@@ -722,7 +724,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dataset",
-        type=list,
+        nargs="+",
         default=IATLAS_DATASETS,
         help="List of dataset names to run for. Optional. Defaults to IATLAS_DATASETS global variable.",
     )
@@ -795,7 +797,7 @@ def main():
         logger = utils.create_logger(
             dataset_name=dataset,
             datahub_tools_path=args.datahub_tools_path,
-            log_file_name="clinical_to_cbioportal_log.txt",
+            log_file_name=LOG_FILE_NAME,
         )
         add_clinical_header(
             input_dfs=cli_dfs,

--- a/local/iatlas/cbioportal_export/clinical_to_cbioportal.py
+++ b/local/iatlas/cbioportal_export/clinical_to_cbioportal.py
@@ -14,9 +14,8 @@ import synapseutils
 
 import utils
 
-#my_agent = "iatlas-cbioportal/0.0.0"
-#syn = synapseclient.Synapse(user_agent=my_agent).login()
-syn = synapseclient.login()
+my_agent = "iatlas-cbioportal/0.0.0"
+syn = synapseclient.Synapse(user_agent=my_agent).login()
 
 EXTRA_COLS = ["study_sample_name", "study_patient_name"]
 

--- a/local/iatlas/cbioportal_export/clinical_to_cbioportal.py
+++ b/local/iatlas/cbioportal_export/clinical_to_cbioportal.py
@@ -680,12 +680,10 @@ def validate_export_files(
     
     for file in REQUIRED_OUTPUT_FILES:
         if file.startswith("cases"): 
-            required_file_path = f"{dataset_dir}/{file}" 
-        else:
             required_file_path = f"{dataset_dir}/case_lists/{file}"
-            
-        required_file_path = f"{dataset_dir}/{file}"
-        if not Path().exists(required_file_path):
+        else:
+            required_file_path = f"{dataset_dir}/{file}"
+        if not Path(required_file_path).exists():
             logger.error(f"Missing REQUIRED OUTPUT FILE: {required_file_path}")
     print("\n\n")
 

--- a/local/iatlas/cbioportal_export/utils.py
+++ b/local/iatlas/cbioportal_export/utils.py
@@ -1,7 +1,42 @@
+import logging
 import os
 import shutil
+import sys
 
 import pandas as pd
+
+
+def create_logger(
+    dataset_name: str, datahub_tools_path: str, log_file_name: str
+) -> logging.Logger:
+    """This creates a logger for the current dataset and process
+
+    Args:
+        dataset_name (str): Name of the dataset
+        datahub_tools_path (str): Path to the datahub tools path repo
+        log_file_name (str): Name of the log file
+
+    Returns:
+        logging.Logger: logger for use in the processing functions
+    """
+    dataset_dir = get_local_dataset_output_folder_path(dataset_name, datahub_tools_path)
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.INFO)
+    stdout_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+    file_handler = logging.FileHandler(
+        f"{dataset_dir}/{log_file_name}", mode="w"
+    )
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    )
+
+    logger.handlers = [stdout_handler, file_handler]
+    return logger
 
 
 def clear_workspace(dir_path: str) -> None:
@@ -12,6 +47,7 @@ def clear_workspace(dir_path: str) -> None:
     """
     shutil.rmtree(dir_path)
     os.makedirs(dir_path, exist_ok=True)
+
 
 def get_local_dataset_output_folder_path(
     dataset_name: str, datahub_tools_path: str


### PR DESCRIPTION
# **Problem:**
The Riaz maf still had some outstanding errors before it could be free of cBioportal validation errors:

- Inconsistent clinical `SAMPLE_ID`s vs `Tumor_Sample_Barcode` values in maf file

```
Sample ID not defined in clinical file; values encountered: ["XXX", "XXX", "XXX]
```

- Missing `case_lists_sequenced.txt` which is needed for verifying that the samples in maf file exist (are sequenced) in the clinical samples

# **Solution:**
In order to process the Riaz dataset through to be validated and ingested by cBioportal, there were additional things that needed to happen:

- Apply the new clinical paper ids mapping so that the clinical `SAMPLE_ID`s and maf IDs were consistent (otherwise we run into inconsistent sample id errors when cross-validating between the two files)
- Add code to call cBioportal's [case list generation code](https://github.com/cBioPortal/datahub-study-curation-tools/blob/master/generate-case-lists/generate_case_lists.py) because it will take care of the logic between creating the all clinical samples case list and sequenced samples case lists (needed for part of maf file validation) that our custom case list code doesn't handle

These two fixes had to be coupled together and modifications had to be made to the clinical file as its files are used as the source of the cross-validation with the maf file's files


# **Testing:**
- Unit tests run
- cBioportal validator passed with no `ERROR`s for the maf file, metadata maf file and sequenced case lists file
