### PR TITLE
[DPE-1437] Remove columns with ALL NAs

### DIFF
--- a/local/iatlas/cbioportal_export/tests/test_clinical_to_cbioportal.py
+++ b/local/iatlas/cbioportal_export/tests/test_clinical_to_cbioportal.py
@@ -362,6 +362,31 @@ def test_that_get_updated_cli_attributes_updates_correctly():
         )
 
 
+@pytest.mark.parametrize(
+    "input_df, expected_cols",
+    (
+        pd.DataFrame(
+            {"a": [None, None, None], "b": [1, None, 3], "c": [None, None, None]}
+        ),
+        ["b"],
+    ),
+    (
+        pd.DataFrame({"a": [None, 2, None], "b": [1, None, 3], "c": [1, None, None]}),
+        ["a", "b", "c"],
+    ),
+    (
+        pd.DataFrame(
+            {"a": [None, None, None], "b": [None, None, None], "c": [None, None, None]}
+        ),
+        ["a", "b", "c"],
+    ),
+    ids=["some_all_na_cols", "no_all_na_cols", "all_all_na_cols"],
+)
+def that_get_all_non_na_columns_returns_expected(input_df, expected_cols):
+    result = cli_to_cbio.get_all_non_na_columns(input_df)
+    assert result == expected_cols
+
+
 def test_that_create_case_lists_map_returns_expected_map():
     # Create a fake clinical file in TSV format
     rows = [


### PR DESCRIPTION
# **Problem:**
When the iAtlas data gets displayed on cBioportal, columns with ALL NAs don't get filtered out and gets displayed in the drop down UI like this: 
<img width="417" height="461" alt="image" src="https://github.com/user-attachments/assets/0da2e73a-0371-4a77-b120-62f78dfa9640" />

This creates a lot of "extra" display options that are kind of sitting in the dropdown UI without any interaction you can do.

JIRA Ticket: https://sagebionetworks.jira.com/browse/DPE-1437

# **Solution:**
We want to subset out the columns on a dataset by dataset basis that have 100% NAs in all rows. 

A new function `get_all_non_na_columns` is created to get the columns with 100% NAs. This is then used during the generate clinical header step so we're excluding columns with all NAs when exporting the clinical files to be uploaded. Validation is added to check that those columns are removed as expected.

# **Testing:**
- Unit tests
- Added validation to make sure no 100% NA columns
- No cbioportal validation errors
