### PR TITLE
[DPE-1453] Process ANDERS clinical dataset

### DIFF
--- a/local/iatlas/cbioportal_export/clinical.py
+++ b/local/iatlas/cbioportal_export/clinical.py
@@ -230,8 +230,9 @@ def add_lens_id_as_sample_display_name(
     input_df: pd.DataFrame, lens_id_mapping: pd.DataFrame, **kwargs
 ) -> pd.DataFrame:
     """Adds in lens_id as clinical attribute SAMPLE_DISPLAY_NAME
-    Note that lens mapping are dataset specific so sample ids can be all numeric values
-    so some conversion to str is needed
+    NOTE: The lens maps are dataset specific so there is a possibility of SAMPLE_ID being of
+    numeric data type so conversion to string is needed to merge with the clinical data where
+    SAMPLE_ID is string data type
 
     Args:
         input_df (pd.DataFrame): input clinical data
@@ -796,7 +797,7 @@ def main():
     parser.add_argument(
         "--lens_id_mapping_synid",
         type=str,
-        help="Synapse id for the study_sample_name (paper ids) to lens id mapping file",
+        help="Synapse id for the study_sample_name (paper ids) to lens id mapping file. Optional. Defaults to None, then adding lens id mapping is skipped",
         default=None
     )
     parser.add_argument(
@@ -833,6 +834,7 @@ def main():
     cli_dfs = split_into_patient_and_sample_data(
         input_data=cli_df, cli_to_cbio_mapping=cli_to_cbio_mapping
     )
+    # Skips the lens mapping when not provided because it's technically optional
     if args.lens_id_mapping_synid is not None:
         lens_id_mapping = get_study_sample_name_to_lens_id_mapping(
             lens_id_mapping_synid=args.lens_id_mapping_synid, logger=main_logger

--- a/local/iatlas/cbioportal_export/load.py
+++ b/local/iatlas/cbioportal_export/load.py
@@ -174,7 +174,7 @@ def main():
         help="Path to cbioportal repo",
     )
     parser.add_argument(
-        "--create-case-lists",
+        "--create_case_lists",
         action="store_true",
         default=False,
         help="Whether to generate the all and sequenced caselists",


### PR DESCRIPTION
# **Problem:**
We need to process the ANDER clinical dataset as part of the iAtlas to cbioportal ingestion work. The dataset has the following main things to address:

- Has all numeric values for the sample_ids used to map in the lens id so will need to convert them
- Has DNA only and RNA samples (sequencing runs) that are not part of the analyses so they will need to be excluded

JIRA: https://sagebionetworks.jira.com/browse/DPE-1453

# **Solution:**
- [Line of code to convert the sample_ids in the lens map to string so it can be merged in](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/122/files#diff-0b8ba0d47465e6c6d3ee2bae70493f2afb814ebc9fda034a36d5680739273172R248)
- [Function to exclude the DNA only and RNA samples (sequencing runs) that are not part of the analyses via pattern in the `sample_name` attribute of `-nr-`, `-nd-`, `-ad-`.](https://github.com/Sage-Bionetworks-Workflows/orca-recipes/pull/122/files#diff-0b8ba0d47465e6c6d3ee2bae70493f2afb814ebc9fda034a36d5680739273172R75) This is to prevent manual removal in the raw clinical data.

# **Testing:**
- Unit tests
- Lens mapping is mapped as expected
- Anders dataset has all unique sample/patient ids after removing samples not part of analyses and passes cbioportal validation
