### PR TITLE
Make CONTRIBUTING.md more prominent in README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 ## Development
 
+The following section is divided into three parts:
+
+1. **Environment** – Development information related to the infrastructure or environment in which DAGs run.
+2. **Structure** – Development information related to DAG logic/code.
+3. **Testing** – Testing DAGs
+
 ### Environment
 
 The development environment breaks down into two categories: Infrastructure and Code. This is because the repo contains both:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains Airflow recipes (DAGs) for data processing and engineer
 
 ## Airflow Development
 
-For instructions on how to set up the development environment and interface with Airflow, see below. For a detailed guide on how to add or update DAGs and make changes to the Airflow infrastucture or environment, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+For instructions on how to set up the development environment and interface with Airflow, see below. For a detailed guide on how to add or update DAGs and make changes to the Airflow infrastructure or environment, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Setting up the Dev Environment 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains Airflow recipes (DAGs) for data processing and engineer
 
 ## Airflow Development
 
+For instructions on how to set up the development environment and interface with Airflow, see below. For a detailed guide on how to add or update DAGs and make changes to the Airflow infrastucture or environment, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ### Setting up the Dev Environment 
 
 A complete Airflow deployment is made up of multiple services running in parallel, so the steps involved in setting up a dev environment are more complex than you may be used to. There are two steps involved in setting up Airflow for development:


### PR DESCRIPTION
# **Problem:**

I should have included these changes with #128, but after merging that PR I found that CONTRIBUTING.md, which contains a plethora of valuable information for developers, was still too deeply buried within README.md.

# **Solution:**

As a preface to the "Airflow Development" section in the README, I give an overview of what sort of "Airflow development" info you can expect in the README vs. CONTRIBUTING

# **Testing:**
NA
