### PR TITLE
Add programmatic grant scrapping with claude API

### DIFF
--- a/src/grants/README.md
+++ b/src/grants/README.md
@@ -1,0 +1,74 @@
+# Grant Ingestion Pipeline
+
+This script scrapes grant information from a list of URLs and outputs a consolidated CSV file.
+
+## Scraping non-federal grants
+
+### Dependencies
+
+You will need the following:
+
+* **Access to the data model Synapse CSV**
+* **A valid Synapse account**, with `synapseclient` configured in your environment
+* **A developer account with Anthropic**
+* **Anthropic API key** stored in your environment as:
+
+  ```bash
+  ANTHROPIC_API_KEY
+  ```
+
+### Setting Up the Environment
+
+1. Ensure you are using **Python 3**.
+2. Install the required Python packages:
+
+   ```bash
+   pip install anthropic requests pandas synapseclient
+   ```
+
+3. Confirm your Synapse credentials are configured (e.g., via `~/.synapseConfig`).
+
+### How to Run
+
+1. Gather a list of URLs to scrape.
+
+   * Provide them in a text file named `urls.txt`, **one URL per line**,
+     **or**
+   * Update the local `urls` variable directly in the script.
+
+   A pre-existing table of URLs is available here:
+   [https://www.synapse.org/Synapse:syn72003087](https://www.synapse.org/Synapse:syn72003087)
+
+2. Run the script:
+
+   ```bash
+   python3 scrape_grants.py
+   ```
+
+3. After completion, check your working directory for the output file:
+
+   ```text
+   all_grants.csv
+   ```
+
+4. Save the `all_grants.csv` to https://www.synapse.org/Synapse:syn72004505
+
+## Running the rest of the ingestion pipeline
+
+1. Run the script:
+
+    ```bash
+    python3 retrieve_grants.py
+    ```
+
+2. This will create the compiled federal + non-federal grant results and upload to a Snowflake table. If you have access to Snowflake and the `DATA_ANALYTICS` role granted to you, you can query the table like so:
+
+    ```sql
+    -- show the entire table with all columns
+    select *
+    from sage.grants.grants_pipeline_test;
+
+    -- select only relevant columns
+    select "title", "funding_amount", "grant_duration", "contact_info", "end_date"
+    from sage.grants.grants_pipeline_test
+    ```

--- a/src/grants/retrieve_grants.py
+++ b/src/grants/retrieve_grants.py
@@ -12,15 +12,14 @@ from synapseclient.models import File
 syn = Synapse()
 syn.login(silent=True)
 
-def step1_a_retrieve_federal_grants(api_url, request_body):
 
-    headers = {
-        "Content-Type": "application/json"
-    }
+def step1_a_retrieve_federal_grants(api_url, request_body):
+    headers = {"Content-Type": "application/json"}
 
     response = requests.post(api_url, json=request_body, headers=headers)
 
-    return response.json()['data']
+    return response.json()["data"]
+
 
 def step1_b_retrieve_non_federal_grants_from_synapse() -> pd.DataFrame:
     """
@@ -33,58 +32,63 @@ def step1_b_retrieve_non_federal_grants_from_synapse() -> pd.DataFrame:
     df = pd.read_csv(file.path, sep=",")
     return df
 
+
 def step2_preliminary_filter(grants_data):
     """
     Filters by:
     1. Closing date for grant proposal
     TODO: add filter for award minimum
     """
-    hits = grants_data['oppHits']
-    
+    hits = grants_data["oppHits"]
+
     month_from_now = datetime.today().date() + relativedelta(months=1)
-    
+
     eligible_grants = []
     for h in hits:
-        if not h['closeDate']:
+        if not h["closeDate"]:
             continue
-        print('processing grant...')
+        print("processing grant...")
         print(f"{h['id']}: {h['title']}")
-        close_date = datetime.strptime(h['closeDate'], "%m/%d/%Y").date()
+        close_date = datetime.strptime(h["closeDate"], "%m/%d/%Y").date()
         print(close_date)
         if not close_date <= month_from_now:
-            print('this grant is eligible')
+            print("this grant is eligible")
             eligible_grants.append(h)
     print(eligible_grants)
     print("final eligible grants for keyword:", len(eligible_grants))
-    print('\n')
+    print("\n")
     return eligible_grants
+
 
 def fetch_opportunity_details(opportunity_id):
     """Fetch opportunity details from Grants.gov API"""
-    headers = {
-        "Content-Type": "application/json"
-    }
-    response = requests.post("https://api.grants.gov/v1/api/fetchOpportunity", headers=headers, json={"opportunityId": opportunity_id})
-    return response.json()['data']
+    headers = {"Content-Type": "application/json"}
+    response = requests.post(
+        "https://api.grants.gov/v1/api/fetchOpportunity",
+        headers=headers,
+        json={"opportunityId": opportunity_id},
+    )
+    return response.json()["data"]
+
 
 def extracrt_opportunity_fields(opportunity_details):
     """Filter opportunity details to get the required fields based on the data model"""
-    synopsis = opportunity_details.get('synopsis', {})
-    
+    synopsis = opportunity_details.get("synopsis", {})
+
     # Handle awardFloor - can be "none" or a number
-    award_floor = synopsis.get('awardFloor', 'none')
-    if award_floor == 'none' or award_floor is None:
+    award_floor = synopsis.get("awardFloor", "none")
+    if award_floor == "none" or award_floor is None:
         funding_amount = None
     else:
         try:
             funding_amount = int(award_floor)
         except (ValueError, TypeError):
             funding_amount = None
-    
+
     # Parse dates
-    post_date = synopsis.get('postingDate')
-    end_date = synopsis.get('responseDate')
-    
+    post_date = synopsis.get("postingDate")
+    end_date = synopsis.get("responseDate")
+
     # Calculate duration in years if both dates exist
     grant_duration = None
     if post_date and end_date:
@@ -96,56 +100,80 @@ def extracrt_opportunity_fields(opportunity_details):
             grant_duration = (end_dt - post_dt).days / 365.25
         except (ValueError, TypeError):
             grant_duration = None
-    
+
     # Create DataFrame from dictionary (single row) - values must be in lists
     import re
+
     print("funding amount:", funding_amount)
-    converted_funding_amount = re.sub(r'\D', '', str(funding_amount)) if funding_amount is not None else None
+    converted_funding_amount = (
+        re.sub(r"\D", "", str(funding_amount)) if funding_amount is not None else None
+    )
     print("converted funding amount:", converted_funding_amount)
     # TODO: Figure out why Snowflake only recognizes the columns when you make it a string (e.g. select "title" works but select title does not)
     data = {
-        'title': [opportunity_details.get('opportunityTitle')],
-        'funding_amount': [converted_funding_amount],
-        'organization': [synopsis.get('agencyContactName')],
-        'contact_info': [synopsis.get('agencyContactEmail')],
-        'data_source': ['grants.gov'],
-        'post_date': [post_date],
-        'end_date': [end_date],
-        'grant_description': [synopsis.get('synopsisDesc')],
-        'grant_duration': [grant_duration],
-        'domain': ['TBD']
+        "id": opportunity_details["id"],
+        "title": [opportunity_details.get("opportunityTitle")],
+        "funding_amount": [converted_funding_amount],
+        "organization": [synopsis.get("agencyContactName")],
+        "contact_info": [synopsis.get("agencyContactEmail")],
+        "data_source": ["grants.gov"],
+        "post_date": [post_date],
+        "end_date": [end_date],
+        "grant_description": [synopsis.get("synopsisDesc")],
+        "grant_duration": [grant_duration],
+        "domain": ["TBD"],
     }
-    
+
     opportunity_details_df = pd.DataFrame(data)
     return opportunity_details_df
+
 
 def step3_append_grant_details(grants_data):
     """Append grant details to the grants data."""
     grants_df = pd.DataFrame()
     for grant in grants_data:
-        opportunity_id = grant['id']
+        opportunity_id = grant["id"]
         grant_details = fetch_opportunity_details(opportunity_id)
         grant_details = extracrt_opportunity_fields(grant_details)
         grants_df = pd.concat([grants_df, grant_details], ignore_index=True)
     return grants_df
 
-def step4_upload_to_snowflake(table_df, table_name, auto_table_create=False, overwrite=False):
+
+def step4_upload_to_snowflake(
+    table_df, table_name, auto_table_create=False, overwrite=False
+):
     """
     Uploads the final table of the pipeline to Snowflake.
     TODO: Replace this with Rixing's snowflake_utils module when that's merged
     TODO: Update credentials to use a service user account instead of personal user account
     """
     conn = snowflake.connector.connect(
-                account='mqzfhld-vp00034',
-                user='jenny.medina@sagebase.org',
-                password=os.getenv("SNOWFLAKE_PAT"),
-                role='DATA_ENGINEER',
-                warehouse='COMPUTE_XSMALL',
-                database='SAGE',
-                schema='DPE'
-            )
-    
-    write_pandas(conn, table_df, table_name, auto_create_table=auto_table_create, overwrite=overwrite)
+        account="mqzfhld-vp00034",
+        user="jenny.medina@sagebase.org",
+        password=os.getenv("SNOWFLAKE_PAT"),
+        role="DATA_ENGINEER",
+        warehouse="COMPUTE_XSMALL",
+        database="SAGE",
+        schema="DPE",
+    )
+    # conn = snowflake.connector.connect(
+    #     account='mqzfhld-vp00034',
+    #     user=os.getenv("SNOW_USER"),
+    #     private_key_file=os.getenv("SNOW_PRIVATE"),
+    #     private_key_file_pwd=os.getenv("SNOW_PRIVATE_PWD"),
+    #     database="SAGE",
+    #     schema="DPE",
+    #     role="DATA_ENGINEER",
+    #     warehouse="compute_xsmall",
+    # )
+    write_pandas(
+        conn,
+        table_df,
+        table_name,
+        auto_create_table=auto_table_create,
+        overwrite=overwrite,
+        quote_identifiers=False,
+    )
 
 
 def all_federal_grants(api_url, request_body):
@@ -157,30 +185,44 @@ def all_federal_grants(api_url, request_body):
 
 if __name__ == "__main__":
     limit_rows = 10
-    kwds = ['alzheimer', 'arthritis', 'autoimmune', 'cancer', 'nf', 'neurofibromatosis', 'longevity', 'elite']
+    kwds = [
+        "alzheimer",
+        "arthritis",
+        "autoimmune",
+        "cancer",
+        "nf",
+        "neurofibromatosis",
+        "longevity",
+        "elite",
+        "data coordinating center",
+        "data management",
+        "open science",
+    ]
     api_url = "https://api.grants.gov/v1/api/search2"
 
     all_fedral_grants = pd.DataFrame()
     for keyword in kwds:
         print("Searching for grants with keyword:", keyword)
         body = {
-                "rows": limit_rows,
-                "keyword": keyword,
-                "eligibilities": "",
-                "agencies": "",
-                "oppStatuses": "forecasted|posted",
-                "aln": "",
-                "fundingCategories": ""
-            }
+            "rows": limit_rows,
+            "keyword": keyword,
+            "eligibilities": "",
+            "agencies": "",
+            "oppStatuses": "forecasted|posted",
+            "aln": "",
+            "fundingCategories": "",
+        }
         grants = all_federal_grants(api_url, body)
         all_fedral_grants = pd.concat([all_fedral_grants, grants], ignore_index=True)
-    
+
     non_federal_grants = step1_b_retrieve_non_federal_grants_from_synapse()
-    all_grants = pd.concat([all_fedral_grants,non_federal_grants])
+    all_grants = pd.concat([all_fedral_grants, non_federal_grants])
     print("ALL GRANTS:", len(all_grants))
     print(all_grants)
     table_df = pd.DataFrame(all_grants)
     print("converted to dataframe:")
     print(table_df)
     print("Uploading to Snowflake...")
-    step4_upload_to_snowflake(table_df, "GRANTS_PIPELINE_TEST",auto_table_create=True, overwrite=True)
+    step4_upload_to_snowflake(
+        table_df, "GRANTS_PIPELINE_TEST", auto_table_create=True, overwrite=True
+    )

--- a/src/grants/scrape_grants.py
+++ b/src/grants/scrape_grants.py
@@ -1,3 +1,19 @@
+"""
+Dependencies: 
+- Access to the data model synapse CSV
+- Developer account on Anthropic
+- API Key token saved as ANTHROPIC_API_KEY in your environment
+- Valid Synapse account with synapse configured in your environment
+
+How to Run:
+
+1. Gather list of 
+2. Set up your environment via:
+pip install anthropic requests pandas synapseclient
+3. Provide a text file urls.txt with list of URLs or update the local urls variable
+4. python3 scrape_grants.py
+5. Check your working directory for a extracted_grants.csv
+""" 
 import anthropic
 import requests
 import os
@@ -29,7 +45,7 @@ def load_data_model(syn : synapseclient.Synapse, data_model_synid : str) -> pd.D
         return None
       
 
-def format_data_model_for_prompt(data_model_df):
+def format_data_model_for_prompt(data_model_df : pd.DataFrame) -> str:
     """Format the data model into a detailed prompt section"""
     prompt_section = "FIELD SPECIFICATIONS:\n\n"
     
@@ -43,7 +59,7 @@ def format_data_model_for_prompt(data_model_df):
     
     return prompt_section
 
-def fetch_webpage_content(url):
+def fetch_webpage_content(url : str) -> str:
     """Fetch the HTML content of a webpage"""
     try:
         headers = {
@@ -55,7 +71,7 @@ def fetch_webpage_content(url):
     except Exception as e:
         return f"Error fetching {url}: {str(e)}"
 
-def extract_grants_with_claude(url, data_model_df):
+def extract_grants_with_claude(url : str, data_model_df : pd.DataFrame) -> str:
     """Use Claude to extract grant information from webpage content"""
     
     # Fetch the webpage content
@@ -128,7 +144,11 @@ Please be thorough and extract all relevant information according to the data mo
         print(f"❌ Error calling Claude API: {e}")
         return None
 
-def process_multiple_urls(urls, data_model_df, output_file="combined_grants.csv"):
+def process_multiple_urls(
+  urls : List[str], 
+  data_model_df : pd.DataFrame, 
+  output_file : str ="combined_grants.csv"
+  ) -> pd.DataFrame:
     """Process multiple URLs and combine results"""
     
     all_results = []
@@ -201,7 +221,7 @@ def main():
             urls = [line.strip() for line in f if line.strip() and not line.startswith('#')]
         print(f"✅ Loaded {len(urls)} URLs from {URLS_FILE}")
     except FileNotFoundError:
-        print(f"⚠️ {URLS_FILE} not found. Using default URLs...")
+        print(f"{URLS_FILE} not found. Using default URLs...")
         urls = [
             "https://www.aacr.org/professionals/research-funding/current-funding-opportunities/",
         ]

--- a/src/grants/scrape_grants.py
+++ b/src/grants/scrape_grants.py
@@ -14,9 +14,11 @@ pip install anthropic requests pandas synapseclient
 4. python3 scrape_grants.py
 5. Check your working directory for a extracted_grants.csv
 """ 
+import os
+from typing import List
+
 import anthropic
 import requests
-import os
 import pandas as pd
 import synapseclient
 

--- a/src/grants/scrape_grants.py
+++ b/src/grants/scrape_grants.py
@@ -1,0 +1,244 @@
+import anthropic
+import requests
+import os
+import pandas as pd
+import synapseclient
+
+# Configuration
+DATA_MODEL_SYNID = "syn72010973"  # Synapse ID to data model file
+URLS_FILE = "urls.txt"  # Path to file with URLs (one per line)
+OUTPUT_FILE = "extracted_grants.csv"
+ANTHROPIC_API_KEY= os.getenv("ANTHROPIC_API_KEY")
+
+def load_data_model(syn : synapseclient.Synapse, data_model_synid : str) -> pd.DataFrame:
+    """Load the data model from a CSV file on synapse
+
+    Args:
+        syn (synapseclient.Synapse): synapse client connection
+        data_model_synid (str): synapse_id of the data model file
+
+    Returns:
+        pd.DataFrame: data model as pandas table
+    """
+    try:
+      df = pd.read_csv(syn.get(data_model_synid).path, sep = ",")
+      # Assuming the CSV has columns like: field_name, description, required
+      return df
+    except Exception as e:
+        print(f"Error loading data model: {e}")
+        return None
+      
+
+def format_data_model_for_prompt(data_model_df):
+    """Format the data model into a detailed prompt section"""
+    prompt_section = "FIELD SPECIFICATIONS:\n\n"
+    
+    for idx, row in data_model_df.iterrows():
+      field_name = row.get('Column_Name', 'Unknown')
+      description = row.get('Column_Definition', 'No description')
+      
+      prompt_section += f"{idx + 1}. **{field_name}**\n"
+      prompt_section += f"   - Description: {description}\n"
+      prompt_section += "\n"
+    
+    return prompt_section
+
+def fetch_webpage_content(url):
+    """Fetch the HTML content of a webpage"""
+    try:
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        }
+        response = requests.get(url, timeout=30, headers=headers)
+        response.raise_for_status()
+        return response.text
+    except Exception as e:
+        return f"Error fetching {url}: {str(e)}"
+
+def extract_grants_with_claude(url, data_model_df):
+    """Use Claude to extract grant information from webpage content"""
+    
+    # Fetch the webpage content
+    print(f"Fetching content from {url}...")
+    webpage_content = fetch_webpage_content(url)
+    
+    if webpage_content.startswith("Error fetching"):
+        print(webpage_content)
+        return None
+    
+    # Initialize Anthropic client
+    client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
+    
+    # Get field names for CSV headers
+    field_names = data_model_df['Column_Name'].tolist()
+    
+    # Format the complete data model for the prompt
+    data_model_prompt = format_data_model_for_prompt(data_model_df)
+    
+    # Create the prompt
+    prompt = f"""Here is the HTML content from {url}:
+
+<webpage_content>
+{webpage_content}
+</webpage_content>
+
+Please analyze this webpage and extract all grant opportunities listed.
+
+<data_model>
+{data_model_prompt}
+</data_model>
+
+EXTRACTION INSTRUCTIONS:
+1. Extract information for each grant based on the field specifications above
+2. Pay careful attention to the description and data type for each field
+3. For example, if a field description mentions "email", extract email addresses for that field
+4. Return the results in CSV format with these exact column headers (in order): {', '.join(field_names)}
+5. If information is not available for a field, use "N/A"
+6. Include all grants found on the page
+7. Do not add any additional text before or after the CSV
+8. Ensure proper CSV escaping for fields containing commas or quotes
+9. Follow any specific format requirements mentioned in the field descriptions
+
+Please be thorough and extract all relevant information according to the data model specifications.
+"""
+    
+    # Call Claude API
+    print("Sending to Claude for analysis...")
+    try:
+        message = client.messages.create(
+            model="claude-sonnet-4-5-20250929",
+            max_tokens=4000,
+            messages=[
+                {"role": "user", "content": prompt}
+            ]
+        )
+        
+        # Extract the response
+        response_text = message.content[0].text
+        
+        # Clean up response (remove markdown code blocks if present)
+        if response_text.startswith("```csv"):
+            response_text = response_text.replace("```csv", "").replace("```", "").strip()
+        elif response_text.startswith("```"):
+            response_text = response_text.replace("```", "").strip()
+            
+        return response_text
+        
+    except Exception as e:
+        print(f"❌ Error calling Claude API: {e}")
+        return None
+
+def process_multiple_urls(urls, data_model_df, output_file="combined_grants.csv"):
+    """Process multiple URLs and combine results"""
+    
+    all_results = []
+    
+    for idx, url in enumerate(urls, 1):
+        print(f"\n{'='*60}")
+        print(f"Processing URL {idx}/{len(urls)}: {url}")
+        print(f"{'='*60}")
+        
+        csv_result = extract_grants_with_claude(url, data_model_df)
+        
+        if csv_result:
+            # Parse CSV result
+            try:
+                from io import StringIO
+                df = pd.read_csv(StringIO(csv_result))
+                df['source_url'] = url  # Add source URL column
+                df['extraction_date'] = pd.Timestamp.now().strftime('%Y-%m-%d %H:%M:%S')
+                all_results.append(df)
+                print(f"✅ Successfully extracted {len(df)} grants from {url}")
+            except Exception as e:
+                print(f"⚠️ Error parsing CSV from {url}: {e}")
+                # Save raw output for debugging
+                debug_file = f"debug_output_{idx}.txt"
+                with open(debug_file, 'w', encoding='utf-8') as f:
+                    f.write(csv_result)
+                print(f"Raw output saved to {debug_file}")
+        else:
+            print(f"❌ Failed to extract grants from {url}")
+    
+    # Combine all results
+    if all_results:
+        combined_df = pd.concat(all_results, ignore_index=True)
+        combined_df.to_csv(output_file, index=False, encoding='utf-8')
+        print(f"\n{'='*60}")
+        print(f"✨ Successfully saved {len(combined_df)} total grants to {output_file}")
+        print(f"{'='*60}")
+        return combined_df
+    else:
+        print("❌ No results to save")
+        return None
+
+def main():
+    """Main execution function"""
+    
+    # Configuration
+    DATA_MODEL_CSV = "data_model.csv"  # Path to your data model CSV
+    URLS_FILE = "urls.txt"  # Path to file with URLs (one per line)
+    OUTPUT_FILE = "extracted_grants.csv"
+    
+    # Load data model from CSV
+    print("="*60)
+    print("Loading data model...")
+    print("="*60)
+    syn = synapseclient.login()
+    data_model_df = load_data_model(syn=syn, data_model_synid = DATA_MODEL_SYNID)
+    
+    # Display the data model
+    print("\nData Model Preview:")
+    print(data_model_df.to_string(index=False))
+    print()
+    
+    # Load URLs
+    print("="*60)
+    print("Loading URLs...")
+    print("="*60)
+    
+    try:
+        with open(URLS_FILE, 'r') as f:
+            urls = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+        print(f"✅ Loaded {len(urls)} URLs from {URLS_FILE}")
+    except FileNotFoundError:
+        print(f"⚠️ {URLS_FILE} not found. Using default URLs...")
+        urls = [
+            "https://www.aacr.org/professionals/research-funding/current-funding-opportunities/",
+        ]
+    
+    print(f"\nURLs to process:")
+    for idx, url in enumerate(urls, 1):
+        print(f"  {idx}. {url}")
+    
+    # Process all URLs
+    print("\n" + "="*60)
+    print("Starting extraction process...")
+    print("="*60)
+    results_df = process_multiple_urls(urls, data_model_df, OUTPUT_FILE)
+    
+    # Display summary
+    if results_df is not None:
+        print("\n" + "="*60)
+        print("EXTRACTION SUMMARY")
+        print("="*60)
+        print(f"   Total grants extracted: {len(results_df)}")
+        print(f"   URLs processed: {len(urls)}")
+        print(f"   Output file: {OUTPUT_FILE}")
+        print(f"   Fields extracted: {len(data_model_df)}")
+        
+        # Show first few rows
+        print("\nPreview of extracted data:")
+        print(results_df.head().to_string())
+        
+        # Show data quality summary
+        print("\nData Quality Summary:")
+        for col in data_model_df['Column_Name']:
+            if col in results_df.columns:
+                filled = results_df[col].notna().sum()
+                total = len(results_df)
+                pct = (filled / total * 100) if total > 0 else 0
+                print(f"   {col}: {filled}/{total} ({pct:.1f}%) filled")
+
+if __name__ == "__main__":
+    main()
+    

--- a/src/grants/scrape_non_federal_grants.py
+++ b/src/grants/scrape_non_federal_grants.py
@@ -1,19 +1,3 @@
-"""
-Dependencies: 
-- Access to the data model synapse CSV
-- Developer account on Anthropic
-- API Key token saved as ANTHROPIC_API_KEY in your environment
-- Valid Synapse account with synapse configured in your environment
-
-How to Run:
-
-1. Gather list of 
-2. Set up your environment via:
-pip install anthropic requests pandas synapseclient
-3. Provide a text file urls.txt with list of URLs or update the local urls variable
-4. python3 scrape_grants.py
-5. Check your working directory for a extracted_grants.csv
-""" 
 import os
 from typing import List
 
@@ -25,7 +9,7 @@ import synapseclient
 # Configuration
 DATA_MODEL_SYNID = "syn72010973"  # Synapse ID to data model file
 URLS_FILE = "urls.txt"  # Path to file with URLs (one per line)
-OUTPUT_FILE = "extracted_grants.csv"
+OUTPUT_FILE = "all_grants.csv"
 ANTHROPIC_API_KEY= os.getenv("ANTHROPIC_API_KEY")
 
 def load_data_model(syn : synapseclient.Synapse, data_model_synid : str) -> pd.DataFrame:


### PR DESCRIPTION
# **Problem:**
Not all grant websites have APIs or databases with data structures easy to scrape using current web scraping tools. Often times we just have a webpage with a list of grants and information formatted throughout. How can we gather the grant information we need that we can get easily from grant websites with APIs.

# **Solution:**
This adds a grant scrapping tool that takes URLs that directly take you to the website page that contains the list of grants and gathers the required information (using the grant ingestion data model) from them via claude API programmatically.

Claude API cannot access URLs directly so the HTML content of the website is first extracted and then claude is prompted to analyze it and extract the grant data

Limitations - have not tested sites where grant info are hidden behind links / PDF links or have a lot of javascript content that you need to click to get to the grant.

# **Testing:**
Tested on a couple grant websites.
If you have access, see here for an full example: https://www.synapse.org/Synapse:syn72011146

Preview:
<img width="962" height="162" alt="image" src="https://github.com/user-attachments/assets/765b0a81-0c45-457a-99ed-f5bd52a6d1ff" />
