### PR TITLE
Fix Synapse URL formatting in multiple DAGs

### DIFF
--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -170,7 +170,7 @@ def datasets_or_projects_created_7_days() -> None:
                 data_type = row.content_type
             else:
                 data_type = row.node_type
-            printed_message = f"{index+1}. <https://www.synapse.org/#!Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|{row.user_name_full_name}>, Public: {row.is_public})\n\n"
+            printed_message = f"{index+1}. <https://www.synapse.org/Synapse:syn{row.id}|*{row.name}*> (Type: {data_type}, Created on: {row.created_on}, Created by: <https://www.synapse.org/Profile:{row.created_by}/profile|{row.user_name_full_name}>, Public: {row.is_public})\n\n"
             if row.is_public:
                 public_ds_message += printed_message
             else:

--- a/dags/synapse_dataset_to_croissant_minimal.py
+++ b/dags/synapse_dataset_to_croissant_minimal.py
@@ -583,7 +583,7 @@ def save_minimal_jsonld_to_s3() -> None:
             })
             dataset = syn_client.get(dataset_id, downloadFile=False)
 
-            link = f"https://www.synapse.org/#!Synapse:{row['id']}"
+            link = f"https://www.synapse.org/Synapse:{row['id']}"
 
             minimal_croissant_file = {
                 "@context": "https://schema.org/",

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -537,7 +537,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
                 size_string = f"< {0:.{SIZE_ROUNDING}f}5 {BYTE_STRING}"
 
             message += (
-                f"{index+1}. <https://www.synapse.org/#!Synapse:{row.project}|{row.name}> - "
+                f"{index+1}. <https://www.synapse.org/Synapse:{row.project}|{row.name}> - "
                 f"{row.downloads_per_project} downloads, {row.number_of_unique_users_downloaded} "
                 f"unique users, {size_string} egressed"
             )


### PR DESCRIPTION
# **Problem:**

- the [Synapse.org](http://synapse.org/) URLs referenced in the croissant files point to a hash fragment version, which is a redirect (since we no longer use this outdated URL scheme in the GWT app routing).

For example, https://www.synapse.org/#!Synapse:syn52623570 should just be https://www.synapse.org/Synapse:syn52623570

# **Solution:**

- Remove extra URL characters

# **Testing:**

- Verified that URLs that will be getting used do resolve to the right redirect
