### PR TITLE
[DPE-1578] Disable `yarn` in container setup to fix `yarn` gpg key expiration blocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 ARG BASE_IMAGE=apache/airflow:2.10.5-python3.10
 FROM $BASE_IMAGE
 
+# Disable Yarn apt repo if present (it can break apt-get update when its signing key rotates/expires)
+RUN if [ -f /etc/apt/sources.list.d/yarn.list ]; then \
+      sed -i 's/^deb /# deb /' /etc/apt/sources.list.d/yarn.list; \
+    fi \
+ && rm -f /usr/share/keyrings/yarn* /etc/apt/keyrings/yarn* 2>/dev/null || true
+
 RUN pip install --upgrade pip
 
 RUN pip install apache-airflow[amazon,celery,snowflake]==2.10.5 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.10.txt"


### PR DESCRIPTION
# **Problem:**
See JIRA Ticket for full context, but essentially the `yarn` gpg key expired across likely all devcontainers so we have to have a temp. workaround in the meanwhile until it gets fixed. This is blocking local development of airflow DAGs using our devcontainers/codespaces.

`yarn` is something that just a node.js/javascript package manager comes with the base devcontainer image that we use for our airflow devcontainer. 


JIRA Ticket: https://sagebionetworks.jira.com/browse/DPE-1578

# **Solution:**
After some research, I don't think `yarn` is a pre-req for our airflow setup (unless we have some webserver setup or custom Airflow UI plugin that we have planned), so I think we can safely disable it in our airflow environment setup and this could become a longer term workaround.

Reasoning for not refreshing the key ourselves is because we'd have to first remove the `yarn` repo anyways and then add steps to refresh the key (whenever we launch a new container / rebuild from scratch) and likely have to add in some permission commands as well in there adding further complexity. These would also all have to be included in our `Dockerfile`.

# **Testing:**
- Tested by following local dev environment setup here: https://github.com/Sage-Bionetworks-Workflows/orca-recipes/blob/main/README.md#airflow-development. Environment was setup successfully with no more error popping up saying `running in recovery mode`
- Was able to access the local codespace airflow server and trigger a validation DAG as part of [these validation steps](https://sagebionetworks.jira.com/browse/GEN-2263?focusedCommentId=284500) without any issues
