### PR TITLE
Don't use deprecated snowflake tables

### DIFF
--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -101,7 +101,7 @@ def synapse_by_the_numbers_past_month() -> None:
                 SELECT
                     COUNT(*) AS DOWNLOADS_LAST_MONTH
                 FROM (
-                    SELECT DISTINCT 
+                    SELECT 
                         user_id,
                         file_handle_id,
                         record_date

--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -93,7 +93,7 @@ def synapse_by_the_numbers_past_month() -> None:
                 SELECT 
                     COUNT(DISTINCT user_id) AS DISTINCT_USER_COUNT
                 FROM 
-                    synapse_data_warehouse.synapse.processedaccess
+                    synapse_data_warehouse.synapse_event.access_event
                 WHERE
                     DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
             ),
@@ -106,7 +106,7 @@ def synapse_by_the_numbers_past_month() -> None:
                         file_handle_id,
                         record_date
                     FROM
-                        synapse_data_warehouse.synapse.filedownload
+                        synapse_data_warehouse.synapse_event.objectdownload_event
                     WHERE
                         DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
                 )

--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -77,7 +77,7 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
                     node_latest.project_id != {SYNAPSE_HOMEPAGE_PROJECT_ID}
             ),
             DEDUP_FILEHANDLE AS (
-                SELECT DISTINCT
+                SELECT
                     PUBLIC_PROJECTS.name,
                     filedownload.user_id,
                     filedownload.file_handle_id AS FD_FILE_HANDLE_ID,

--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -85,7 +85,7 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
                     filedownload.project_id,
                     file_latest.content_size
                 FROM
-                    synapse_data_warehouse.synapse.filedownload
+                    synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN
                     PUBLIC_PROJECTS
                 ON

--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -79,25 +79,25 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
             DEDUP_FILEHANDLE AS (
                 SELECT
                     PUBLIC_PROJECTS.name,
-                    filedownload.user_id,
-                    filedownload.file_handle_id AS FD_FILE_HANDLE_ID,
-                    filedownload.record_date,
-                    filedownload.project_id,
+                    objectdownload_event.user_id,
+                    objectdownload_event.file_handle_id AS FD_FILE_HANDLE_ID,
+                    objectdownload_event.record_date,
+                    objectdownload_event.project_id,
                     file_latest.content_size
                 FROM
                     synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN
                     PUBLIC_PROJECTS
                 ON
-                    filedownload.project_id = PUBLIC_PROJECTS.project_id
+                    objectdownload_event.project_id = PUBLIC_PROJECTS.project_id
                 INNER JOIN
                     synapse_data_warehouse.synapse.file_latest
                 ON
-                    filedownload.file_handle_id = file_latest.id
+                    objectdownload_event.file_handle_id = file_latest.id
                 WHERE
-                    filedownload.record_date > DATEADD(DAY, -30, '{context["params"]["current_date"]}')
+                    objectdownload_event.record_date > DATEADD(DAY, -30, '{context["params"]["current_date"]}')
                 AND 
-                    filedownload.record_date <= '{context["params"]["current_date"]}'
+                    objectdownload_event.record_date <= '{context["params"]["current_date"]}'
             ),
 
             DOWNLOAD_STAT AS (

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -75,7 +75,7 @@ def top_public_synapse_projects_all_time_from_snowflake() -> None:
                     node_latest.project_id != {SYNAPSE_HOMEPAGE_PROJECT_ID}
                         ),
             DEDUP_FILEHANDLE AS (
-                SELECT DISTINCT
+                SELECT
                     PUBLIC_PROJECTS.name,
                     filedownload.user_id,
                     filedownload.file_handle_id AS FD_FILE_HANDLE_ID,

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -83,7 +83,7 @@ def top_public_synapse_projects_all_time_from_snowflake() -> None:
                     filedownload.project_id,
                     file_latest.content_size
                 FROM
-                    synapse_data_warehouse.synapse.filedownload
+                    synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN
                     PUBLIC_PROJECTS
                 ON

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -77,21 +77,21 @@ def top_public_synapse_projects_all_time_from_snowflake() -> None:
             DEDUP_FILEHANDLE AS (
                 SELECT
                     PUBLIC_PROJECTS.name,
-                    filedownload.user_id,
-                    filedownload.file_handle_id AS FD_FILE_HANDLE_ID,
-                    filedownload.record_date,
-                    filedownload.project_id,
+                    objectdownload_event.user_id,
+                    objectdownload_event.file_handle_id AS FD_FILE_HANDLE_ID,
+                    objectdownload_event.record_date,
+                    objectdownload_event.project_id,
                     file_latest.content_size
                 FROM
                     synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN
                     PUBLIC_PROJECTS
                 ON
-                    filedownload.project_id = PUBLIC_PROJECTS.project_id
+                    objectdownload_event.project_id = PUBLIC_PROJECTS.project_id
                 INNER JOIN
                     synapse_data_warehouse.synapse.file_latest
                 ON
-                    filedownload.file_handle_id = file_latest.id
+                    objectdownload_event.file_handle_id = file_latest.id
             ),
 
             DOWNLOAD_STAT AS (

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -181,7 +181,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
                     filedownload.project_id,
                     file_latest.content_size
                 FROM
-                    synapse_data_warehouse.synapse.filedownload
+                    synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN
                     PUBLIC_PROJECTS
                 ON
@@ -368,7 +368,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
                     filedownload.project_id,
                     file_latest.content_size
                 FROM
-                    synapse_data_warehouse.synapse.filedownload
+                    synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN PROJECT_INFO
                 ON filedownload.project_id = PROJECT_INFO.project_id
                 INNER JOIN synapse_data_warehouse.synapse.file_latest

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -173,7 +173,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
                     node_latest.project_id != %(homepage_id)s
             ),
             DEDUP_FILEHANDLE AS (
-                SELECT DISTINCT
+                SELECT
                     PUBLIC_PROJECTS.name,
                     filedownload.user_id,
                     filedownload.file_handle_id AS FD_FILE_HANDLE_ID,
@@ -359,7 +359,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
             
             DEDUP_FILEHANDLE AS (
                 -- Get download information for files in projects from file views
-                SELECT DISTINCT
+                SELECT
                     PROJECT_INFO.group_name,
                     PROJECT_INFO.file_view_id,
                     filedownload.user_id,

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -175,23 +175,23 @@ def top_public_synapse_projects_from_snowflake() -> None:
             DEDUP_FILEHANDLE AS (
                 SELECT
                     PUBLIC_PROJECTS.name,
-                    filedownload.user_id,
-                    filedownload.file_handle_id AS FD_FILE_HANDLE_ID,
-                    filedownload.record_date,
-                    filedownload.project_id,
+                    objectdownload_event.user_id,
+                    objectdownload_event.file_handle_id AS FD_FILE_HANDLE_ID,
+                    objectdownload_event.record_date,
+                    objectdownload_event.project_id,
                     file_latest.content_size
                 FROM
                     synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN
                     PUBLIC_PROJECTS
                 ON
-                    filedownload.project_id = PUBLIC_PROJECTS.project_id
+                    objectdownload_event.project_id = PUBLIC_PROJECTS.project_id
                 INNER JOIN
                     synapse_data_warehouse.synapse.file_latest
                 ON
-                    filedownload.file_handle_id = file_latest.id
+                    objectdownload_event.file_handle_id = file_latest.id
                 WHERE
-                    filedownload.record_date = {date_clause}
+                    objectdownload_event.record_date = {date_clause}
             ),
 
             DOWNLOAD_STAT AS (
@@ -362,19 +362,19 @@ def top_public_synapse_projects_from_snowflake() -> None:
                 SELECT
                     PROJECT_INFO.group_name,
                     PROJECT_INFO.file_view_id,
-                    filedownload.user_id,
-                    filedownload.file_handle_id AS FD_FILE_HANDLE_ID,
-                    filedownload.record_date,
-                    filedownload.project_id,
+                    objectdownload_event.user_id,
+                    objectdownload_event.file_handle_id AS FD_FILE_HANDLE_ID,
+                    objectdownload_event.record_date,
+                    objectdownload_event.project_id,
                     file_latest.content_size
                 FROM
                     synapse_data_warehouse.synapse_event.objectdownload_event
                 INNER JOIN PROJECT_INFO
-                ON filedownload.project_id = PROJECT_INFO.project_id
+                ON objectdownload_event.project_id = PROJECT_INFO.project_id
                 INNER JOIN synapse_data_warehouse.synapse.file_latest
-                ON filedownload.file_handle_id = file_latest.id
+                ON objectdownload_event.file_handle_id = file_latest.id
                 WHERE
-                    filedownload.record_date = {date_clause}
+                    objectdownload_event.record_date = {date_clause}
             ),
             
             DOWNLOAD_STAT AS (

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -97,7 +97,7 @@ def trending_projects_snapshot() -> None:
                 ),
                 RECENT_DOWNLOADS AS (
                     SELECT PROJECT_ID, RECORD_DATE, USER_ID
-                    FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE.FILEDOWNLOAD
+                    FROM SYNAPSE_DATA_WAREHOUSE.SYNAPSE_EVENT.OBJECTDOWNLOAD_EVENT
                     WHERE 1=1
                     AND DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
                     AND STACK = 'prod'


### PR DESCRIPTION
# **Problem:**

* synapse.fileupload replaced by synapse_event.fileupload_event
* synapse.filedownload replaced by synapse_event.objectdownload_event 
* synapse.processedaccess replaced by synapse_event.access_event

The queries using `filedownload` has de-duplication which is now removed because `objectdownload_event` has been deduplicated

# **Solution:**
Use new tables

# **Testing:**
NA