### PR TITLE
Test and restructure 4 other DAGs

### DIFF
--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -11,16 +11,17 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
+    "synapse_results_table": Param("syn55382267", type="string"),
 }
 
 dag_config = {
-    "schedule_interval": "0 0 * * *",
+    "schedule": "0 0 * * *",
     "start_date": datetime(2024, 4, 1),
     "catchup": False,
     "default_args": {
@@ -30,7 +31,6 @@ dag_config = {
     "params": dag_params,
 }
 
-SYNAPSE_RESULTS_TABLE = "syn55382267"
 SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 
@@ -161,7 +161,7 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
 
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         syn_hook.client.store(
-            synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
+            synapseclient.Table(schema=context["params"]["synapse_results_table"], values=data)
         )
 
     top_downloads = get_all_time_downloads_from_snowflake()
@@ -170,4 +170,8 @@ def top_public_synapse_projects_30_days_from_snowflake() -> None:
     top_downloads >> push_to_synapse_table
 
 
-top_public_synapse_projects_30_days_from_snowflake()
+dag = top_public_synapse_projects_30_days_from_snowflake()
+
+if __name__ == "__main__":
+    # Replace with a test Synapse table ID before running locally
+    dag.test(run_conf={"synapse_results_table": "syn74496599"})

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -10,15 +10,16 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
+    "synapse_results_table": Param("syn55259224", type="string"),
 }
 
 dag_config = {
-    "schedule_interval": "0 0 1 * *",
+    "schedule": "0 0 1 * *",
     "start_date": datetime(2024, 4, 1),
     "catchup": False,
     "default_args": {
@@ -28,7 +29,6 @@ dag_config = {
     "params": dag_params,
 }
 
-SYNAPSE_RESULTS_TABLE = "syn55259224"
 SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 
@@ -154,7 +154,7 @@ def top_public_synapse_projects_all_time_from_snowflake() -> None:
 
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         syn_hook.client.store(
-            synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
+            synapseclient.Table(schema=context["params"]["synapse_results_table"], values=data)
         )
 
     top_downloads = get_all_time_downloads_from_snowflake()
@@ -163,4 +163,8 @@ def top_public_synapse_projects_all_time_from_snowflake() -> None:
     top_downloads >> push_to_synapse_table
 
 
-top_public_synapse_projects_all_time_from_snowflake()
+dag = top_public_synapse_projects_all_time_from_snowflake()
+
+if __name__ == "__main__":
+    # Replace with a test Synapse table ID before running locally
+    dag.test(run_conf={"synapse_results_table": "syn74496606"})

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -19,7 +19,7 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+from src.synapse_hook import SynapseHook
 from slack_sdk import WebClient
 import json
 
@@ -39,10 +39,11 @@ dag_params = {
     #           {"file_view_id": "789012", "group_name": "Group B"}]'
     "fileview_groups": Param(
         '[{"file_view_id": "20446927", "group_name": "HTAN1"},{"file_view_id": "51489960", "group_name": "ELITE"},{"file_view_id": "16858331", "group_name": "NF-OSI"},{"file_view_id": "27210848", "group_name": "MC2"},{"file_view_id": "52794526", "group_name": "GENIE"}]', type="string"),
+    "synapse_results_table": Param("syn53696951", type="string"),
 }
 
 dag_config = {
-    "schedule_interval": "0 18 * * *",
+    "schedule": "0 18 * * *",
     "start_date": datetime(2024, 2, 20),
     "catchup": False,
     "default_args": {
@@ -57,8 +58,6 @@ BYTE_STRING = "GiB"
 # 30 is the power of 2 for GiB, 40 is the power of 2 for TiB
 POWER_OF_TWO = 30
 
-# ID of the Synapse table where aggregated results will be stored for public viewing
-SYNAPSE_RESULTS_TABLE = "syn53696951"
 # ID of the Synapse homepage project, excluded from download stats
 SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
@@ -628,7 +627,7 @@ def top_public_synapse_projects_from_snowflake() -> None:
 
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         syn_hook.client.store(
-            synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
+            synapseclient.Table(schema=context["params"]["synapse_results_table"], values=data)
         )
 
     public_downloads = get_public_downloads_from_snowflake()
@@ -650,4 +649,14 @@ def top_public_synapse_projects_from_snowflake() -> None:
     top_downloads >> push_to_synapse_table
 
 
-top_public_synapse_projects_from_snowflake()
+dag = top_public_synapse_projects_from_snowflake()
+
+if __name__ == "__main__":
+    # backfill=True skips Slack posting; backfill_date set to today to avoid querying from 1900-01-01
+    # Replace synapse_results_table with a test table ID before running locally
+    from datetime import date
+    dag.test(run_conf={
+        "backfill": True,
+        "backfill_date": date.today().strftime("%Y-%m-%d"),
+        "synapse_results_table": "syn74496611",
+    })

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -21,22 +21,22 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+from src.synapse_hook import SynapseHook
 
 
-SYNAPSE_RESULTS_TABLE = "syn61597055"
 SYNAPSE_HOMEPAGE_PROJECT_ID = 23593546
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "current_date": Param(date.today().strftime("%Y-%m-%d"), type="string"),
-    "month_to_run": Param((date.today() - relativedelta(months=1)).strftime("%Y-%m-%d"), type="string")
+    "month_to_run": Param((date.today() - relativedelta(months=1)).strftime("%Y-%m-%d"), type="string"),
+    "synapse_results_table": Param("syn61597055", type="string"),
     }
 
 dag_config = {
     # run on the 2nd of every month at midnight
-    "schedule_interval": "0 0 2 * *",
+    "schedule": "0 0 2 * *",
     "start_date": datetime(2024, 1, 1),
     "catchup": False,
     "default_args": {
@@ -182,7 +182,7 @@ def trending_projects_snapshot() -> None:
 
         syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
         syn_hook.client.store(
-            synapseclient.Table(schema=SYNAPSE_RESULTS_TABLE, values=data)
+            synapseclient.Table(schema=context["params"]["synapse_results_table"], values=data)
         )
 
     project_snapshot = get_trending_project_snapshot()
@@ -191,4 +191,8 @@ def trending_projects_snapshot() -> None:
     project_snapshot >> push_to_synapse_table
 
 
-trending_projects_snapshot()
+dag = trending_projects_snapshot()
+
+if __name__ == "__main__":
+    # Replace with a test Synapse table ID before running locally
+    dag.test(run_conf={"synapse_results_table": "syn74496614"})


### PR DESCRIPTION
# **Problem:**

- 4 DAGs (`top-public-synapse-projects-30-days-from-snowflake`, `top-public-synapse-projects-all-time-from-snowflake`, `top-public-synapse-projects-from-snowflake`, `trending-projects-snapshot`) could not be run or tested locally because:
  - The Synapse results table was hardcoded as a module-level constant, making it impossible to override for local testing without editing the file
  - `schedule_interval` was deprecated in Airflow 2.4 in favor of `schedule`
  - `SynapseHook` was imported from `orca.services.synapse` rather than the local `src.synapse_hook` used by the rest of the repo

# **Solution:**

- Promoted `SYNAPSE_RESULTS_TABLE` from a module-level constant to a DAG param (`synapse_results_table`) in each DAG, defaulting to the production table ID — this allows the table to be overridden via `run_conf` at test time without touching production
- Updated each push task to read the table ID from `context["params"]["synapse_results_table"]` instead of the constant
- Added `dag = func()` + `if __name__ == "__main__": dag.test(run_conf={...})` blocks to each DAG, matching the pattern already established in `synapse-by-the-numbers-dag.py`
- For `top-public-synapse-projects-from-snowflake`, the test block also sets `backfill=True` (to skip Slack posting) and `backfill_date` to today (to avoid querying from the 1900-01-01 default)
- Replaced `schedule_interval` with `schedule` across all 4 DAGs
- Updated `SynapseHook` import to `from src.synapse_hook import SynapseHook` across all 4 DAGs

# **Testing:**

- Each DAG can now be run locally via `python dags/<dag-file>.py` once a test Synapse table ID is substituted into the `run_conf` in the `if __name__ == "__main__"` block
- Test table IDs are already wired in for each DAG; production table IDs remain as the param defaults and are unaffected by this change