### PR TITLE
[SNOW-397] New Troubleshooting section for expired Codespace secrets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -386,12 +386,4 @@ If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_K
 
 **To fix it:**
 
-1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
-
-   > [!NOTE]
-   > You will need admin permissions in the `org-sagebase-dpe-prod` account to do this.
-2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key (see [Phase 3 of the key rotation runbook](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-3%3A-Update-Use-Case-1-(GitHub-Codespaces))).
-3. Rebuild your Codespace (or restart it) so the new credentials are injected into the environment.
-
-> [!NOTE]
-> If you are developing locally with VS Code Dev Containers rather than Codespaces, you will not have access to the pre-configured Codespace secrets and must supply valid AWS credentials manually in your `.env` file. See the [Docker Compose setup in the README](./README.md#docker-compose) for details.
+Follow the [Rotating `airflow-secrets-backend` IAM User Credentials](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-3:-Update-Use-Case-1-(GitHub-Codespaces)) runbook on Confluence, which covers how to rotate the keys, update the Codespace secrets, and validate the update.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException)
    env | grep AWS
    ```
 2. Locate the value of `AWS_ACCESS_KEY_ID` in the output.
-3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the [AWS Console](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/3389325317/Connecting+to+AWS+EKS+Kubernetes+K8s+cluster) (`org-sagebase-dpe-prod` account).
+3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the AWS Console (`org-sagebase-dpe-prod` account).
    Alternatively, you can list active keys with the AWS CLI:
    ```console
    aws iam list-access-keys --user-name airflow-secrets-backend --profile <your-profile-name>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,7 +388,7 @@ If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_K
 **To fix it:**
 
 1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Note: you will need admin permissions in the `org-sagebase-dpe-prod` account to do this. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
-2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key.
+2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key (see [Phase 3 of the key rotation runbook](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-3%3A-Update-Use-Case-1-(GitHub-Codespaces))).
 3. Rebuild your Codespace (or restart it) so the new credentials are injected into the environment.
 
 > [!NOTE]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,3 +353,35 @@ To contribute a new challenge:
 1. **Merge your Pull Request**: Once your changes have been tested, your PR is ready for merge and a maintainer will ensure your DAG is created and running in Airflow production!
 
 By following these guidelines, you will successfully contribute a deployable challenge DAG customized for your needs.
+
+----
+
+### Troubleshooting
+
+This section is a living reference for potential issues you may encounter when testing your DAG. If you run into a problem not covered here, consider documenting it for future contributors.
+
+#### Airflow provider hooks failing to connect — outdated Codespace secrets
+
+If you are testing your DAG in a Codespaces environment (see [Dev Container setup in the README](./README.md#codespaces)) and your Airflow provider hooks (e.g., `SynapseHook`, `SnowflakeHook`, `S3Hook`) are failing to connect, it may be caused by expired AWS credentials in the repository's Codespace secrets.
+
+As noted in the [Secrets](#secrets) section, this repository uses an IAM user (`airflow-secrets-backend`) whose access keys are stored as Codespace secrets so that Airflow can reach AWS Secrets Manager in `dpe-prod`. These credentials must be rotated every 90 days. If they have expired, Airflow will be unable to resolve any connections or variables backed by Secrets Manager, which can surface as `KeyError` import errors or hook connection failures — even when the connection ID strings themselves look correct.
+
+**To verify this is the cause:**
+
+1. Open a terminal in your Codespace and run:
+   ```console
+   env | grep AWS
+   ```
+2. Locate the value of `AWS_ACCESS_KEY_ID` in the output.
+3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the AWS Console under the `org-sagebase-dpe-prod` account.
+
+If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_KEY`) is almost certainly stale as well.
+
+**To fix it:**
+
+1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one.
+2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key.
+3. Rebuild your Codespace (or restart it) so the new credentials are injected into the environment.
+
+> [!NOTE]
+> If you are developing locally with VS Code Dev Containers rather than Codespaces, you will not have access to the pre-configured Codespace secrets and must supply valid AWS credentials manually in your `.env` file. See the [Docker Compose setup in the README](./README.md#docker-compose) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,7 +377,7 @@ botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException)
    env | grep AWS
    ```
 2. Locate the value of `AWS_ACCESS_KEY_ID` in the output.
-3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the AWS Console under the `org-sagebase-dpe-prod` account.
+3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the [AWS Console](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/3389325317/Connecting+to+AWS+EKS+Kubernetes+K8s+cluster) (`org-sagebase-dpe-prod` account).
    Alternatively, you can list active keys with the AWS CLI:
    ```console
    aws iam list-access-keys --user-name airflow-secrets-backend --profile <your-profile-name>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,7 +387,7 @@ If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_K
 
 **To fix it:**
 
-1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
+1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Note: you will need admin permissions in the `org-sagebase-dpe-prod` account to do this. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
 2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key.
 3. Rebuild your Codespace (or restart it) so the new credentials are injected into the environment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,7 +379,7 @@ If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_K
 
 **To fix it:**
 
-1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one.
+1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
 2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key.
 3. Rebuild your Codespace (or restart it) so the new credentials are injected into the environment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,9 +286,8 @@ Modify everything in `<>` and remove the `<>` when complete:
       - "nextflow_tower"
 ```
 
-Note that while `synapse_conn_id` and `aws_conn_id` are customizable, we do have connection IDs already in-place
-for you to use that will connect you to Synapse (through DPE's ORCA Service Account) and to AWS. But feel free to swap
-these for your own if they do not suit your needs.
+> [!NOTE]
+> While `synapse_conn_id` and `aws_conn_id` are customizable, we do have connection IDs already in-place for you to use that will connect you to Synapse (through DPE's ORCA Service Account) and to AWS. Feel free to swap these for your own if they do not suit your needs.
 
 ```
 synapse_conn_id: "SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN"
@@ -387,7 +386,10 @@ If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_K
 
 **To fix it:**
 
-1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Note: you will need admin permissions in the `org-sagebase-dpe-prod` account to do this. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
+1. In the AWS Console (`org-sagebase-dpe-prod`, `us-east-1`), navigate to **IAM → Users → `airflow-secrets-backend`** and rotate the access key by creating a new one and deactivating the old one. Instructions for rotating the access key can be found [here](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-2%3A-Delete-Old-Keys-and-Create-New-Keys).
+
+   > [!NOTE]
+   > You will need admin permissions in the `org-sagebase-dpe-prod` account to do this.
 2. Update the corresponding Codespace secrets in this repository's GitHub settings with the new access key ID and secret access key (see [Phase 3 of the key rotation runbook](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-3%3A-Update-Use-Case-1-(GitHub-Codespaces))).
 3. Rebuild your Codespace (or restart it) so the new credentials are injected into the environment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -364,7 +364,11 @@ This section is a living reference for potential issues you may encounter when t
 
 If you are testing your DAG in a Codespaces environment (see [Dev Container setup in the README](./README.md#codespaces)) and your Airflow provider hooks (e.g., `SynapseHook`, `SnowflakeHook`, `S3Hook`) are failing to connect, it may be caused by expired AWS credentials in the repository's Codespace secrets.
 
-As noted in the [Secrets](#secrets) section, this repository uses an IAM user (`airflow-secrets-backend`) whose access keys are stored as Codespace secrets so that Airflow can reach AWS Secrets Manager in `dpe-prod`. These credentials must be rotated every 90 days. If they have expired, Airflow will be unable to resolve any connections or variables backed by Secrets Manager, which can surface as `KeyError` import errors or hook connection failures — even when the connection ID strings themselves look correct.
+As noted in the [Secrets](#secrets) section, this repository uses an IAM user (`airflow-secrets-backend`) whose access keys are stored as Codespace secrets so that Airflow can reach AWS Secrets Manager in `dpe-prod`. These credentials must be rotated every 90 days. If they have expired, Airflow will be unable to resolve any connections or variables backed by Secrets Manager, which can surface as `KeyError` import errors, hook connection failures, or `botocore` token errors such as:
+```
+botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException) when calling the GetSecretValue operation: The security token included in the request is invalid.
+```
+— even when the connection ID strings themselves look correct.
 
 **To verify this is the cause:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,6 +378,10 @@ botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException)
    ```
 2. Locate the value of `AWS_ACCESS_KEY_ID` in the output.
 3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the AWS Console under the `org-sagebase-dpe-prod` account.
+   Alternatively, you can list active keys with the AWS CLI:
+   ```console
+   aws iam list-access-keys --user-name airflow-secrets-backend --profile <your-profile-name>
+   ```
 
 If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_KEY`) is almost certainly stale as well.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Congrats! You have completed set up of the dev environment.
 
 Airflow is made up of multiple components or services working together. The webserver exposes a browser-accessible port, but in a development environment we often want to interface with Airflow through its CLI.
 
+NOTE: If secrets are not accessible or hooks are failing to connect when testing a DAG, see the [Troubleshooting](./CONTRIBUTING.md#troubleshooting) section in CONTRIBUTING.md for common causes and fixes — including how to diagnose and resolve expired Codespace secrets.
+
 #### CLI
 
 We can see which services are currently running:
@@ -98,8 +100,6 @@ for secret in all_secrets:
     if any([secret["Name"].startswith(p) for p in secret_prefixes]):
         print(secret["Name"])
 ```
-
-If secrets are not accessible or hooks are failing to connect when testing a DAG, see the [Troubleshooting](./CONTRIBUTING.md#troubleshooting) section in CONTRIBUTING.md for common causes and fixes — including how to diagnose and resolve expired Codespace secrets.
 
 #### Browser
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ for secret in all_secrets:
         print(secret["Name"])
 ```
 
+If secrets are not accessible or hooks are failing to connect when testing a DAG, see the [Troubleshooting](./CONTRIBUTING.md#troubleshooting) section in CONTRIBUTING.md for common causes and fixes — including how to diagnose and resolve expired Codespace secrets.
+
 #### Browser
 
 We can see which ports our Airflow services expose under `PORTS`:


### PR DESCRIPTION
# Problem

There is no documented resource for common issues that contributors might run into when testing DAGs — for example, Airflow provider hooks failing to connect in Codespaces due to expired AWS credentials stored as Codespace secrets.

# Solution

- [x] New **Troubleshooting** section in `CONTRIBUTING.md` for issues likely to happen
- [x] Referencing this section in `README.md`

# Testing
N/A