### PR TITLE
[POC] MWAA: Add initial MWAA DAG infrastructure

### DIFF
--- a/mwaa/README.md
+++ b/mwaa/README.md
@@ -63,4 +63,5 @@ Credentials (Snowflake, Synapse, etc.) are stored as Airflow Connections in the 
 ## Local Development
 
 1. For local development and testing, use the `@dag.test`
-2. You must install `pip install apache-airflow==2.10.3`
+2. Install `pip install apache-airflow==2.10.3`
+3. Install `pip install -r requirements.txt`

--- a/mwaa/README.md
+++ b/mwaa/README.md
@@ -62,4 +62,5 @@ Credentials (Snowflake, Synapse, etc.) are stored as Airflow Connections in the 
 
 ## Local Development
 
-For local development and testing, use the `@dag.test`
+1. For local development and testing, use the `@dag.test`
+2. You must install `pip install apache-airflow==2.10.3`

--- a/mwaa/README.md
+++ b/mwaa/README.md
@@ -1,0 +1,65 @@
+# MWAA DAG Development Guide
+
+Amazon Managed Workflows for Apache Airflow (MWAA) has several constraints and conventions that differ from local Airflow. This document covers what you need to know before writing or deploying a DAG.
+
+## Requirements and Dependency Constraints
+
+Dependencies are declared in `mwaa/requirements.txt`. The first line pins a constraints file from the official Airflow release:
+
+```
+-c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt
+```
+
+All packages must be compatible with this constraints file. MWAA enforces this at environment startup — a conflicting package will prevent the environment from loading entirely.
+
+**Known quirks:**
+- `synapseclient[pandas]~=4.0` installs successfully even though the constraints file pins `urllib3` to a version that appears incompatible. MWAA resolves this at install time; do not add an explicit `urllib3` pin to work around it.
+- Stick to packages already listed or commented out in `requirements.txt` as a reference — they have been tested against the constraints file.
+- Before adding a new package, verify it does not conflict with pinned transitive dependencies in the constraints file.
+
+## Syncing DAGs to S3
+
+MWAA reads DAGs directly from an S3 bucket. The sync step is not yet automated — DAG files must be uploaded manually to the designated S3 bucket in the AWS account. The bucket path and sync process are to be documented once set up.
+
+DAG files live under `mwaa/dags/`. Upload the entire `dags/` directory (including the `src/` subdirectory — see below) to the S3 bucket prefix that MWAA is configured to watch.
+
+## Business Logic in `src/`
+
+Shared Python modules can be placed in `mwaa/dags/src/`. MWAA picks up this directory alongside the DAG files, so business logic placed there is importable inside tasks:
+
+```python
+from src.synapse_hook import SynapseHook
+```
+
+Keeping logic in `src/` rather than inline in DAG files has two benefits:
+1. It can be unit-tested independently of Airflow.
+2. It is reusable across multiple DAGs.
+
+Always include an `__init__.py` in any new subdirectory under `src/`.
+
+## Serialization: No Dataclasses
+
+MWAA uses Airflow's DAG serialization, which serializes task return values to the XCom backend as JSON. Python `dataclasses` (and any class relying on `pickle`-based serialization) do not survive this round-trip.
+
+**Rule:** task functions must accept and return only JSON-serializable types — `dict`, `list`, `str`, `int`, `float`, `bool`, or `None`. Do not use `dataclasses`, `NamedTuple`, or any custom class as a task input or output.
+
+Instead of:
+```python
+@dataclass
+class Metrics:
+    total_size: float
+    active_users: int
+```
+
+Use a plain dict:
+```python
+{"total_size": 1.23, "active_users": 456}
+```
+
+## Airflow Connections
+
+Credentials (Snowflake, Synapse, etc.) are stored as Airflow Connections in the MWAA environment via AWS secrets manager. DAG parameters expose the connection ID so it can be overridden at trigger time without changing code. See `synapse_hook.py` for the pattern used to resolve a connection with a fallback to an environment variable for local runs.
+
+## Local Development
+
+For local development and testing, use the `@dag.test`

--- a/mwaa/dags/src/synapse_hook.py
+++ b/mwaa/dags/src/synapse_hook.py
@@ -1,0 +1,39 @@
+import os
+
+import synapseclient
+
+
+class SynapseHook:
+    """Airflow hook for Synapse. Resolves credentials from an Airflow connection
+    (password field = auth token) with a fallback to SYNAPSE_AUTH_TOKEN env var
+    for local runs."""
+
+    def __init__(self, conn_id: str) -> None:
+        self.conn_id = conn_id
+        self._client: synapseclient.Synapse | None = None
+
+    @property
+    def client(self) -> synapseclient.Synapse:
+        if self._client is None:
+            self._client = self._login()
+        return self._client
+
+    def _login(self) -> synapseclient.Synapse:
+        auth_token = self._resolve_token()
+        syn = synapseclient.Synapse()
+        syn.login(authToken=auth_token, silent=True)
+        return syn
+
+    def _resolve_token(self) -> str:
+        try:
+            from airflow.hooks.base import BaseHook
+
+            return BaseHook.get_connection(self.conn_id).password
+        except Exception:
+            token = os.environ.get("SYNAPSE_AUTH_TOKEN")
+            if not token:
+                raise EnvironmentError(
+                    f"Could not resolve Airflow connection '{self.conn_id}' and "
+                    "SYNAPSE_AUTH_TOKEN env var is not set."
+                )
+            return token

--- a/mwaa/dags/synapse-by-the-numbers-dag.py
+++ b/mwaa/dags/synapse-by-the-numbers-dag.py
@@ -1,0 +1,113 @@
+"""Test DAG for synapse-by-the-numbers on MWAA. No schedule — trigger manually."""
+
+from datetime import date, datetime
+from dateutil.relativedelta import relativedelta
+from typing import List
+
+import synapseclient
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from src.synapse_hook import SynapseHook
+
+dag_params = {
+    "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),
+    "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
+    "month_to_run": Param((date.today() - relativedelta(months=1)).strftime("%Y-%m-%d"), type="string"),
+    "synapse_results_table": Param("syn74496297", type="string"),
+}
+
+dag_config = {
+    "schedule": None,
+    "start_date": datetime(2024, 7, 1),
+    "catchup": False,
+    "default_args": {"retries": 0},
+    "tags": ["snowflake", "test"],
+    "params": dag_params,
+}
+
+
+@dag(**dag_config)
+def test_synapse_by_the_numbers_past_month() -> None:
+    """Test version of synapse_by_the_numbers — manual trigger only, writes to test table."""
+
+    @task
+    def get_synapse_monthly_metrics(**context) -> List[dict]:
+        snow_hook = SnowflakeHook(context["params"]["snowflake_developer_service_conn"])
+        ctx = snow_hook.get_conn()
+        cs = ctx.cursor()
+        query = f"""
+            WITH FILE_SIZES AS (
+                SELECT DISTINCT
+                    file_latest.id,
+                    content_size
+                FROM
+                    synapse_data_warehouse.synapse.node_latest
+                JOIN
+                    synapse_data_warehouse.synapse.file_latest
+                    ON node_latest.file_handle_id = file_latest.id
+                UNION
+                SELECT DISTINCT
+                    file_latest.id,
+                    content_size
+                FROM
+                    synapse_data_warehouse.synapse.filehandleassociation_latest
+                JOIN
+                    synapse_data_warehouse.synapse.file_latest
+                    ON filehandleassociation_latest.filehandleid = file_latest.id
+                WHERE
+                    filehandleassociation_latest.associatetype = 'TableEntity'
+            ),
+            TOTAL_SIZE AS (
+                SELECT SUM(content_size) / POWER(2, 50) AS SIZE_IN_PETABYTES FROM FILE_SIZES
+            ),
+            MONTHLY_ACTIVE_USERS AS (
+                SELECT COUNT(DISTINCT user_id) AS DISTINCT_USER_COUNT
+                FROM synapse_data_warehouse.synapse_event.access_event
+                WHERE DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
+            ),
+            MONTHLY_DOWNLOADS AS (
+                SELECT COUNT(*) AS DOWNLOADS_LAST_MONTH
+                FROM (
+                    SELECT user_id, file_handle_id, record_date
+                    FROM synapse_data_warehouse.synapse_event.objectdownload_event
+                    WHERE DATE_TRUNC('MONTH', RECORD_DATE) = DATE_TRUNC('MONTH', DATE('{context["params"]["month_to_run"]}'))
+                )
+            )
+            SELECT
+                TOTAL_SIZE.SIZE_IN_PETABYTES,
+                MONTHLY_ACTIVE_USERS.DISTINCT_USER_COUNT,
+                MONTHLY_DOWNLOADS.DOWNLOADS_LAST_MONTH
+            FROM TOTAL_SIZE, MONTHLY_ACTIVE_USERS, MONTHLY_DOWNLOADS;
+            """
+        cs.execute(query)
+        df = cs.fetch_pandas_all()
+        return [
+            {
+                "total_data_size_in_pib": row["SIZE_IN_PETABYTES"],
+                "active_users_last_month": int(row["DISTINCT_USER_COUNT"]),
+                "total_downloads_last_month": int(row["DOWNLOADS_LAST_MONTH"]),
+            }
+            for _, row in df.iterrows()
+        ]
+
+    @task
+    def push_results_to_synapse_table(metrics: list, **context) -> None:
+        today = date.today()
+        data = [
+            [today, m["total_data_size_in_pib"], m["active_users_last_month"], m["total_downloads_last_month"]]
+            for m in metrics
+        ]
+        syn_hook = SynapseHook(context["params"]["synapse_conn_id"])
+        syn_hook.client.store(
+            synapseclient.Table(schema=context["params"]["synapse_results_table"], values=data)
+        )
+
+    top_downloads = get_synapse_monthly_metrics()
+    push_results_to_synapse_table(metrics=top_downloads)
+
+
+dag = test_synapse_by_the_numbers_past_month()
+
+if __name__ == "__main__":
+    dag.test(run_conf={"synapse_results_table": "syn74496297"})

--- a/mwaa/requirements.txt
+++ b/mwaa/requirements.txt
@@ -1,0 +1,14 @@
+# -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt
+apache-airflow-providers-amazon ==9.0.0
+apache-airflow-providers-celery ==3.8.3
+apache-airflow-providers-snowflake ==5.8.0
+synapseclient[pandas]~=4.0
+slack-sdk >=3.27
+# snowflake-connector-python ==3.12.3
+# py-orca[all] == 1.5.2
+# pandas <3.0.0
+# pendulum~=3.0.0
+# jsonata-python ~=0.5.3
+# boto3 >=1.7.0,<2.0
+# requests ~=2.31
+# PyYAML ~=6.0.2


### PR DESCRIPTION
# **Problem:**

- No infrastructure existed for running Airflow DAGs on Amazon Managed Workflows for Apache Airflow (MWAA).
- The existing DAGs and local Airflow setup were not structured for MWAA deployment.
- Kubernetes deployment of Airflow has high complexity and context switch cost to maintain

# **Solution:**

- MWAA serverless deployment has less flexibility, but allows team to focus only on DAG development
- Paired with this: https://github.com/Sage-Bionetworks-IT/mwaa-infra/pull/1/changes, we deploy on MWAA
- Added `mwaa/` directory containing all MWAA-specific files:
  - `mwaa/requirements.txt` — pinned dependencies compatible with the Airflow 2.10.3 constraints file for Python 3.11.
  - `mwaa/dags/synapse-by-the-numbers-dag.py` — proof-of-concept DAG that pulls monthly Synapse metrics from Snowflake and writes results to a Synapse table. Manually triggered only (no schedule).
  - `mwaa/dags/src/synapse_hook.py` — reusable Airflow hook for Synapse authentication; resolves credentials from an Airflow Connection (backed by AWS Secrets Manager) with a fallback to `SYNAPSE_AUTH_TOKEN` env var for local runs.
  - `mwaa/dags/src/__init__.py` — makes `src/` importable as a package within DAG tasks.
  - `mwaa/README.md` — developer guide covering MWAA-specific constraints: dependency pinning, S3 sync workflow (pending setup), business logic placement in `src/`, JSON-only XCom serialization (no dataclasses), and Airflow Connections via AWS Secrets Manager.
- DAG S3 sync is not yet automated; manual upload to the designated S3 bucket is required until that process is established.

# **Testing:**

- DAG was validated locally using `dag.test()` (`if __name__ == "__main__"` block in the DAG file).
- `SynapseHook` credential resolution tested with `SYNAPSE_AUTH_TOKEN` env var fallback for local runs.
- No automated tests added yet — business logic in `src/` is structured to enable unit testing in a follow-up.