### PR TITLE
[GEN-2607] Modify GENIE Releases Info to update the Patient/Sample tracking table

### DIFF
--- a/src/genie/genie_bpc_releases.yaml
+++ b/src/genie/genie_bpc_releases.yaml
@@ -1,13 +1,28 @@
 # Valid Public Releases 
 - cohort: nsclc
-  version: public_02_2
+  version: public_02_0
   clinical_synid: syn30358089
   cbioportal_synid: syn30358098
 
 - cohort: crc
-  version: public_02_2
+  version: public_02_0
   clinical_synid: syn39802567
   cbioportal_synid: syn39802595
+
+- cohort: brca
+  version: public_01_0
+  clinical_synid: syn71825206
+  cbioportal_synid: syn71825207
+
+- cohort: panc
+  version: public_01_0
+  clinical_synid: syn72666498
+  cbioportal_synid: syn72666426
+
+- cohort: prostate
+  version: public_01_0
+  clinical_synid: syn73963145
+  cbioportal_synid: syn73963143
 
 # Valid Consortium Releases + Public Previews
 - cohort: bladder
@@ -23,7 +38,7 @@
 - cohort: brca
   version: public_preview_01_0
   clinical_synid: syn53507114
-  cbioportal_synid: null
+  cbioportal_synid: syn71816211
 
 - cohort: brca
   version: consortium_01_1
@@ -34,16 +49,6 @@
   version: consortium_01_2
   clinical_synid: syn39802381
   cbioportal_synid: syn32299078
-
-- cohort: crc
-  version: consortium_01_1
-  clinical_synid: syn24166685
-  cbioportal_synid: syn23561876
-
-- cohort: crc
-  version: consortium_01_2
-  clinical_synid: syn26046784
-  cbioportal_synid: syn25998993
 
 - cohort: crc
   version: consortium_01_3
@@ -84,11 +89,6 @@
   version: public_preview_02_0
   clinical_synid: syn27245047
   cbioportal_synid: syn27199149
-
-- cohort: nsclc
-  version: consortium_02_1
-  clinical_synid: syn25982471
-  cbioportal_synid: syn25471745
 
 - cohort: nsclc
   version: consortium_02_2
@@ -143,7 +143,7 @@
 - cohort: prostate
   version: public_preview_01_0
   clinical_synid: syn53507066
-  cbioportal_synid: null
+  cbioportal_synid: syn73963030
 
 - cohort: renal
   version: consortium_01_1

--- a/src/genie/genie_sp_releases.yaml
+++ b/src/genie/genie_sp_releases.yaml
@@ -44,4 +44,13 @@
     - syn49498203
     - syn49498213
 
-
+- cohort: her2
+  patient_id_key: record_id
+  sample_id_key: cpt_genie_sample_id
+  table_name: redcap_export
+  file_synid:
+    - syn74210818
+    - syn74210869
+    - syn74210891
+    - syn74210901
+    - syn74210908

--- a/src/genie/main_genie_ingestion.py
+++ b/src/genie/main_genie_ingestion.py
@@ -32,6 +32,9 @@ RELEASES_TO_SKIP = [
     "Release 14",
     "Release 15",
     "Release 16",
+    "Release 17",
+    "Release 18",
+    "Release 20"
 ]
 
 PROJECT_SYNID = "syn7492881"

--- a/tests/genie/test_main_genie_ingestion.py
+++ b/tests/genie/test_main_genie_ingestion.py
@@ -168,11 +168,11 @@ def test_append_df_logs_success_rowcount_and_chunks():
 @pytest.mark.parametrize(
     "release_path, expected",
     [
-        (("Releases/Release 17", "synX"), True),
+        (("Releases/Release 19", "synX"), True),
         (("Releases/Release 16", "synX"), False),  # skipped list
         (("Releases/Release 00", "synX"), False),  # skipped list
-        (("Release 17", "synX"), False),  # not enough levels
-        (("Releases/Release 17/Extra", "synX"), False),  # too many levels
+        (("Release 19", "synX"), False),  # not enough levels
+        (("Releases/Release 19/Extra", "synX"), False),  # too many levels
     ],
 )
 def test_is_valid_release_path_returns_expected(release_path, expected):
@@ -434,11 +434,11 @@ def test_main_walks_releases_skips_invalid_paths_and_closes_conn_when_not_inject
     walk_output = [
         (
             ("Releases/Release 16", "synOld"),
-            [("19.3-consortium", "synR1")],
+            [("17.3-consortium", "synR1")],
             [],
         ),  # skipped
         (
-            ("Releases/Release 17", "synNew"),
+            ("Releases/Release 19", "synNew"),
             [("19.3-consortium", "synR2")],
             [],
         ),  # processed
@@ -478,7 +478,7 @@ def test_main_does_not_close_conn_when_injected():
     conn_obj = MagicMock(name="conn_obj")
 
     walk_output = [
-        (("Releases/Release 17", "synNew"), [("19.3-consortium", "synR2")], []),
+        (("Releases/Release 19", "synNew"), [("19.3-consortium", "synR2")], []),
     ]
 
     with patch.object(


### PR DESCRIPTION
# **Problem:**

The list of releases for generating the patient/sample tracking table is currently outdated.

# **Solution:**
Update the config file and release to skip list in the code to retrieve the current list 