### PR TITLE
[GEN-2650] GENIE validation DAG takes longer than 8 hours

### DIFF
--- a/dags/genie/genie-nf-validate.py
+++ b/dags/genie/genie-nf-validate.py
@@ -19,7 +19,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 1,17 * * *",
+    "schedule_interval": "0 5,17 * * *",
     "start_date": datetime(2023, 2, 21),
     "catchup": False,
     "default_args": {


### PR DESCRIPTION
# **Problem:**

GENIE validation DAG takes longer than 8 hours
<img width="214" height="425" alt="image" src="https://github.com/user-attachments/assets/2d16f3d1-8350-44f2-8ed2-776355eb01ba" />

# **Solution:**
Do 12 hour interval so validation passes. 

```
10:00 AM PDT → 17:00 UTC
10:00 PM PDT → 05:00 UTC (next day UTC)
```

# **Testing:**
NA
