### PR TITLE
[IT-4153] Use developer AWS SSO credentials instead of shared IAM key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,16 @@ AIRFLOW_UID="50000"
 
 # AWS credentials for the Airflow Secrets backend (AWS Secrets Manager, dpe-prod).
 # Authenticate with your OWN AWS Identity Center (SSO) credentials. Pick ONE option.
+# See the README "AWS credentials" section for setup and the commands to run.
 #
-# Option 1 — Local Dev Container / VS Code (recommended locally):
-#   Mount your host ~/.aws and select an SSO profile. Tokens auto-refresh.
-#   Run `aws sso login --profile <your-sso-profile>` first.
+# Option 1 — Local Dev Container / VS Code (recommended locally): set an SSO profile;
+#   your mounted ~/.aws auto-refreshes tokens.
 # AWS_PROFILE="<your-sso-profile>"
 #   Only set HOST_AWS_DIR if your AWS config is not at $HOME/.aws (absolute path required):
 # HOST_AWS_DIR="/absolute/path/to/.aws"
 #
-# Option 2 — GitHub Codespaces (no host ~/.aws to mount):
-#   Export short-lived credentials into this file with:
-#     aws sso login --profile <your-sso-profile>
-#     bash scripts/aws-sso-to-env.sh <your-sso-profile>
-#   which appends the three values below. They expire; re-run to refresh.
+# Option 2 — GitHub Codespaces (no host ~/.aws to mount): `scripts/aws-sso-to-env.sh`
+#   fills in the three short-lived values below. They expire; re-run to refresh.
 # AWS_ACCESS_KEY_ID="..."
 # AWS_SECRET_ACCESS_KEY="..."
 # AWS_SESSION_TOKEN="..."

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,20 @@
 AIRFLOW_UID="50000"
+
+# AWS credentials for the Airflow Secrets backend (AWS Secrets Manager, dpe-prod).
+# Authenticate with your OWN AWS Identity Center (SSO) credentials. Pick ONE option.
+#
+# Option 1 — Local Dev Container / VS Code (recommended locally):
+#   Mount your host ~/.aws and select an SSO profile. Tokens auto-refresh.
+#   Run `aws sso login --profile <your-sso-profile>` first.
+# AWS_PROFILE="<your-sso-profile>"
+#   Only set HOST_AWS_DIR if your AWS config is not at $HOME/.aws (absolute path required):
+# HOST_AWS_DIR="/absolute/path/to/.aws"
+#
+# Option 2 — GitHub Codespaces (no host ~/.aws to mount):
+#   Export short-lived credentials into this file with:
+#     aws sso login --profile <your-sso-profile>
+#     bash scripts/aws-sso-to-env.sh <your-sso-profile>
+#   which appends the three values below. They expire; re-run to refresh.
 # AWS_ACCESS_KEY_ID="..."
 # AWS_SECRET_ACCESS_KEY="..."
 # AWS_SESSION_TOKEN="..."
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -573,13 +573,13 @@ Airflow secrets (_e.g._ connections and variables) are stored in Secrets Manager
 
 These are all located in AWS Secrets Manager in the `dpe-prod` account.
 
-Developers access these secrets with their own AWS Identity Center (SSO) credentials — there is no shared IAM user or long-lived access key to manage or rotate. Configure an SSO profile once (`aws configure sso`, start URL `https://d-906769aa66.awsapps.com/start`, region `us-east-1`, account `766808016710`, `Developer` role) and provide it to the containers per the [AWS credentials](./README.md#aws-credentials-required-for-all-dev-container-options) section of the README. In deployed Airflow, the pods assume an IRSA role (`airflow-croissant`) and no credentials are stored in the connection secrets.
+Developers access these secrets with their own AWS Identity Center (SSO) credentials — there is no shared IAM user or long-lived access key to manage or rotate. Set up an SSO profile once and log in per the [AWS credentials](./README.md#aws-credentials-required-for-all-options) section of the README (the source of truth for the `aws configure sso` / `aws sso login` steps). In deployed Airflow, the pods assume an IRSA role (`airflow-croissant`) and no credentials are stored in the connection secrets.
 
 ### Creating a new secret
 
 New secrets must be created in AWS Secrets Manager in the `dpe-prod` account.
 
-1. You will need at least **Developer** access to the account.
+1. You will need at least **Developer** (or **Administrator**) access to the account.
 1. Make sure your region is set to **us-east-1**.
 1. For connection URIs, the secret name should have the prefix `airflow/connections/`
 (i.e. `airflow/connections/MY_SECRET_CONNECTION_STRING`). Variables should have the prefix `airflow/variables/` (i.e. `airflow/variables/MY_SECRET_VARIABLE`).
@@ -760,22 +760,9 @@ botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException)
 ```
 — even when the connection ID strings themselves look correct.
 
-**To fix it, refresh your SSO session:**
+**To fix it, refresh your SSO session** by re-running the credential steps for your path in the README's [AWS credentials](./README.md#aws-credentials-required-for-all-options) section (`aws sso login`, plus `scripts/aws-sso-to-env.sh` + a stack restart in Codespaces).
 
-* **Local Dev Container / VS Code** (using `AWS_PROFILE` + a mounted `~/.aws`):
-  ```console
-  aws sso login --profile <your-sso-profile>
-  ```
-  The refreshed token is picked up automatically; no container restart is needed.
-
-* **Codespaces** (using exported credentials in `.env`): re-run the helper to write fresh short-lived credentials, then restart the stack so the containers pick them up:
-  ```console
-  aws sso login --profile <your-sso-profile>
-  bash scripts/aws-sso-to-env.sh <your-sso-profile>
-  docker compose up --build --detach
-  ```
-
-If it still fails, confirm your profile is configured and you are assigned the `Developer` role in `dpe-prod` (`766808016710`):
+If it still fails, confirm your profile is configured and you are assigned the `Developer` (or `Administrator`) role in `dpe-prod` (`766808016710`):
 ```console
 aws sts get-caller-identity --profile <your-sso-profile>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -573,7 +573,7 @@ Airflow secrets (_e.g._ connections and variables) are stored in Secrets Manager
 
 These are all located in AWS Secrets Manager in the `dpe-prod` account.
 
-This repository uses an IAM User `airflow-secrets-backend` to access the secrets. Access keys for the IAM account are stored in this repository as codespace secrets, enabling Airflow deployments in our configured codespaces environment to retrieve connection URIs and secret variables from `dpe-prod`. The credentials used in the repository's codespace secrets must be rotated manually within the AWS console, and updated every 90 days.
+Developers access these secrets with their own AWS Identity Center (SSO) credentials — there is no shared IAM user or long-lived access key to manage or rotate. Configure an SSO profile once (`aws configure sso`, start URL `https://d-906769aa66.awsapps.com/start`, region `us-east-1`, account `766808016710`, `Developer` role) and provide it to the containers per the [AWS credentials](./README.md#aws-credentials-required-for-all-dev-container-options) section of the README. In deployed Airflow, the pods assume an IRSA role (`airflow-croissant`) and no credentials are stored in the connection secrets.
 
 ### Creating a new secret
 
@@ -752,31 +752,30 @@ By following these guidelines, you will successfully contribute a deployable cha
 
 This section is a living reference for potential issues you may encounter when testing your DAG. If you run into a problem not covered here, consider documenting it for future contributors.
 
-#### Airflow Provider Hooks Failing to Connect — Outdated Codespace Secrets
+#### Airflow Provider Hooks Failing to Connect — Expired SSO Credentials
 
-If you are testing your DAG in a Codespaces environment (see [Dev Container setup in the README](./README.md#codespaces)) and your Airflow provider hooks (e.g., `SynapseHook`, `SnowflakeHook`, `S3Hook`) are failing to connect, it may be caused by expired AWS credentials in the repository's Codespace secrets.
-
-As noted in the [Secrets](#secrets) section, this repository uses an IAM user (`airflow-secrets-backend`) whose access keys are stored as Codespace secrets so that Airflow can reach AWS Secrets Manager in `dpe-prod`. These credentials must be rotated every 90 days. If they have expired, Airflow will be unable to resolve any connections or variables backed by Secrets Manager, which can surface as `KeyError` import errors, hook connection failures, or `botocore` token errors such as:
+If your Airflow provider hooks (e.g., `SynapseHook`, `SnowflakeHook`, `S3Hook`) are failing to connect, it is most likely because your AWS Identity Center (SSO) session has expired. Airflow resolves connections and variables from AWS Secrets Manager in `dpe-prod` using your own SSO credentials (see the [Secrets](#secrets) section). When the session expires, Airflow can no longer resolve any Secrets-Manager-backed connection or variable, which can surface as `KeyError` import errors, hook connection failures, or `botocore` token errors such as:
 ```
 botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException) when calling the GetSecretValue operation: The security token included in the request is invalid.
 ```
 — even when the connection ID strings themselves look correct.
 
-**To verify this is the cause:**
+**To fix it, refresh your SSO session:**
 
-1. Open a terminal in your Codespace and run:
-   ```console
-   env | grep AWS
-   ```
-2. Locate the value of `AWS_ACCESS_KEY_ID` in the output.
-3. Compare it against the active access key for the `airflow-secrets-backend` IAM user in the AWS Console (`org-sagebase-dpe-prod` account).
-   Alternatively, you can list active keys with the AWS CLI:
-   ```console
-   aws iam list-access-keys --user-name airflow-secrets-backend --profile <your-profile-name>
-   ```
+* **Local Dev Container / VS Code** (using `AWS_PROFILE` + a mounted `~/.aws`):
+  ```console
+  aws sso login --profile <your-sso-profile>
+  ```
+  The refreshed token is picked up automatically; no container restart is needed.
 
-If the access key ID does not match, the secret access key (`AWS_SECRET_ACCESS_KEY`) is almost certainly stale as well.
+* **Codespaces** (using exported credentials in `.env`): re-run the helper to write fresh short-lived credentials, then restart the stack so the containers pick them up:
+  ```console
+  aws sso login --profile <your-sso-profile>
+  bash scripts/aws-sso-to-env.sh <your-sso-profile>
+  docker compose up --build --detach
+  ```
 
-**To fix it:**
-
-Follow the [Rotating `airflow-secrets-backend` IAM User Credentials](https://sagebionetworks.jira.com/wiki/spaces/DPE/pages/4530602005/Rotating+airflow-secrets-backend+IAM+User+Credentials#Phase-3:-Update-Use-Case-1-(GitHub-Codespaces)) runbook on Confluence, which covers how to rotate the keys, update the Codespace secrets, and validate the update.
+If it still fails, confirm your profile is configured and you are assigned the `Developer` role in `dpe-prod` (`766808016710`):
+```console
+aws sts get-caller-identity --profile <your-sso-profile>
+```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Airflow Development](#airflow-development)
   - [Setting up the Dev Environment](#setting-up-the-dev-environment)
     - [Dev Container](#dev-container)
+      - [AWS credentials](#aws-credentials-required-for-all-dev-container-options)
       - [Codespaces](#codespaces)
       - [VS Code](#vs-code)
     - [Docker Compose](#docker-compose)
@@ -43,9 +44,24 @@ A complete Airflow deployment is made up of multiple services running in paralle
 
 #### Dev Container
 
-There are multiple ways to set up and interface with a dev container, depending on whether you want an IDE-agnostic approach, a VS Code workflow with the Dev Containers extension, or a cloud option like GitHub Codespaces. The cloud option is the most straightforward, and saves us the hassle of configuring Airflow secrets, although because the infrastructure is running in the cloud, there is a limit on how much time we can develop before we need to pay for the service.
+There are multiple ways to set up and interface with a dev container, depending on whether you want an IDE-agnostic approach, a VS Code workflow with the Dev Containers extension, or a cloud option like GitHub Codespaces. The cloud option is the most straightforward, although because the infrastructure is running in the cloud, there is a limit on how much time we can develop before we need to pay for the service.
 
 * Note: The environment setup for the Dev Container is defined in [Dockerfile](./Dockerfile). _How_ we deploy the container locally is defined in [devcontainer.json](.devcontainer/devcontainer.json).
+
+##### AWS credentials (required for all dev container options)
+
+The Airflow Secrets backend reads connections and variables from AWS Secrets Manager in the `dpe-prod` account. Authenticate with your **own** AWS Identity Center (SSO) credentials — there is no shared IAM user.
+
+One-time setup: configure an SSO profile with `aws configure sso` using start URL `https://d-906769aa66.awsapps.com/start`, region `us-east-1`, account `766808016710`, and the `Developer` role. Then log in:
+
+```console
+aws sso login --profile <your-sso-profile>
+```
+
+You supply these credentials to the containers differently depending on where you run:
+
+* **Local Dev Container / VS Code** — set `AWS_PROFILE` (and, if your AWS config is not at `$HOME/.aws`, `HOST_AWS_DIR`) in `.env`. Your `~/.aws` is mounted read-only into the containers and SSO tokens refresh automatically.
+* **Codespaces** — run `aws sso login` inside the Codespace, then `bash scripts/aws-sso-to-env.sh <your-sso-profile>` to write short-lived credentials into `.env`. They expire; re-run the script to refresh.
 
 ##### Codespaces
 
@@ -58,17 +74,16 @@ There are multiple ways to set up and interface with a dev container, depending 
 
 Visual Studio Code provides an extension so that your IDE terminal and other development tools are run within a dev container. Follow the instructions [here](https://code.visualstudio.com/docs/devcontainers/tutorial) to set up the Dev Containers extension. Do not create a new dev container, but rather use the existing configuration by opening the Command Palette (CMD+Shift+p by default on Mac) → "Dev Containers: Reopen in Container."
 
-With this option, you won't be able to use the pre-configured Airflow Secrets as you would in Codespaces. Alternatively, you can [connect to Codespaces as a remote environment from within VS Code](https://docs.github.com/en/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code).
+Set `AWS_PROFILE` in `.env` (see [AWS credentials](#aws-credentials-required-for-all-dev-container-options) above) so the container can reach the Airflow Secrets backend. Alternatively, you can [connect to Codespaces as a remote environment from within VS Code](https://docs.github.com/en/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code).
 
 #### Docker Compose
 
 Ensure that your Docker installation is up to date (we use [Docker Compose V2](https://docs.docker.com/compose/compose-v2/)). It's recommended that you deploy from within the included dev container (previous section).
 
-We pass environment variables to our build via the `.env` file. We use AWS as our Airflow Secrets backend, although if you are deploying within Codespaces, there's no need to include AWS credentials in the `.env` file since a default IAM user has already been configured in this repository's secrets.
+We pass environment variables to our build via the `.env` file. Configure your AWS credentials there following the [AWS credentials](#aws-credentials-required-for-all-dev-container-options) section above (set `AWS_PROFILE` locally, or run `scripts/aws-sso-to-env.sh` in Codespaces).
 
 ```console
-# Duplicate example `.env` file
-# Add AWS credentials if you are *not* using Codespaces.
+# Duplicate example `.env` file, then set your AWS credentials in it.
 cp .env.example .env
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 - [Example Workflows](#example-workflows)
 - [Airflow Development](#airflow-development)
   - [Setting up the Dev Environment](#setting-up-the-dev-environment)
+    - [AWS credentials](#aws-credentials-required-for-all-options)
     - [Dev Container](#dev-container)
-      - [AWS credentials](#aws-credentials-required-for-all-dev-container-options)
       - [Codespaces](#codespaces)
       - [VS Code](#vs-code)
     - [Docker Compose](#docker-compose)
@@ -42,26 +42,31 @@ A complete Airflow deployment is made up of multiple services running in paralle
 1. (Highly recommended) Develop within the provided dev container. A dev container is a virtual machine (e.g., Docker container) that standardizes tools, libraries, and configs for consistent development across machines. This provides us with a consistent environment for the next step.
 2. Run docker compose to deploy the full suite of containerized services.
 
-#### Dev Container
+Regardless of which path you take — Codespaces, a local dev container, or [local development without a dev container](#local-development-without-dev-container) — you first need AWS credentials, since every path resolves Airflow's secrets from AWS Secrets Manager.
 
-There are multiple ways to set up and interface with a dev container, depending on whether you want an IDE-agnostic approach, a VS Code workflow with the Dev Containers extension, or a cloud option like GitHub Codespaces. The cloud option is the most straightforward, although because the infrastructure is running in the cloud, there is a limit on how much time we can develop before we need to pay for the service.
-
-* Note: The environment setup for the Dev Container is defined in [Dockerfile](./Dockerfile). _How_ we deploy the container locally is defined in [devcontainer.json](.devcontainer/devcontainer.json).
-
-##### AWS credentials (required for all dev container options)
+#### AWS credentials (required for all options)
 
 The Airflow Secrets backend reads connections and variables from AWS Secrets Manager in the `dpe-prod` account. Authenticate with your **own** AWS Identity Center (SSO) credentials — there is no shared IAM user.
 
-One-time setup: configure an SSO profile with `aws configure sso` using start URL `https://d-906769aa66.awsapps.com/start`, region `us-east-1`, account `766808016710`, and the `Developer` role. Then log in:
+**One-time setup:** configure an SSO profile with `aws configure sso` using start URL `https://d-906769aa66.awsapps.com/start`, region `us-east-1`, account `766808016710`, and the `Developer` (or `Administrator`) role.
+
+**Every session:** log in to refresh your SSO token (this is the common first step for all paths below):
 
 ```console
 aws sso login --profile <your-sso-profile>
 ```
 
-You supply these credentials to the containers differently depending on where you run:
+Then supply the credentials to Airflow, which differs by path:
 
 * **Local Dev Container / VS Code** — set `AWS_PROFILE` (and, if your AWS config is not at `$HOME/.aws`, `HOST_AWS_DIR`) in `.env`. Your `~/.aws` is mounted read-only into the containers and SSO tokens refresh automatically.
-* **Codespaces** — run `aws sso login` inside the Codespace, then `bash scripts/aws-sso-to-env.sh <your-sso-profile>` to write short-lived credentials into `.env`. They expire; re-run the script to refresh.
+* **Codespaces** — run `bash scripts/aws-sso-to-env.sh <your-sso-profile>` to write short-lived credentials into `.env` (there is no host `~/.aws` to mount). They expire; re-run the script to refresh.
+* **Local without a dev container** — point the secrets backend at your profile via `AIRFLOW__SECRETS__BACKEND_KWARGS`; see [that section](#3-configure-environment-variables).
+
+#### Dev Container
+
+There are multiple ways to set up and interface with a dev container, depending on whether you want an IDE-agnostic approach, a VS Code workflow with the Dev Containers extension, or a cloud option like GitHub Codespaces. The cloud option is the most straightforward, although because the infrastructure is running in the cloud, there is a limit on how much time we can develop before we need to pay for the service.
+
+* Note: The environment setup for the Dev Container is defined in [Dockerfile](./Dockerfile). _How_ we deploy the container locally is defined in [devcontainer.json](.devcontainer/devcontainer.json).
 
 ##### Codespaces
 
@@ -74,13 +79,13 @@ You supply these credentials to the containers differently depending on where yo
 
 Visual Studio Code provides an extension so that your IDE terminal and other development tools are run within a dev container. Follow the instructions [here](https://code.visualstudio.com/docs/devcontainers/tutorial) to set up the Dev Containers extension. Do not create a new dev container, but rather use the existing configuration by opening the Command Palette (CMD+Shift+p by default on Mac) → "Dev Containers: Reopen in Container."
 
-Set `AWS_PROFILE` in `.env` (see [AWS credentials](#aws-credentials-required-for-all-dev-container-options) above) so the container can reach the Airflow Secrets backend. Alternatively, you can [connect to Codespaces as a remote environment from within VS Code](https://docs.github.com/en/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code).
+Set `AWS_PROFILE` in `.env` (see [AWS credentials](#aws-credentials-required-for-all-options) above) so the container can reach the Airflow Secrets backend. Alternatively, you can [connect to Codespaces as a remote environment from within VS Code](https://docs.github.com/en/codespaces/developing-in-a-codespace/using-github-codespaces-in-visual-studio-code).
 
 #### Docker Compose
 
 Ensure that your Docker installation is up to date (we use [Docker Compose V2](https://docs.docker.com/compose/compose-v2/)). It's recommended that you deploy from within the included dev container (previous section).
 
-We pass environment variables to our build via the `.env` file. Configure your AWS credentials there following the [AWS credentials](#aws-credentials-required-for-all-dev-container-options) section above (set `AWS_PROFILE` locally, or run `scripts/aws-sso-to-env.sh` in Codespaces).
+We pass environment variables to our build via the `.env` file. Configure your AWS credentials there following the [AWS credentials](#aws-credentials-required-for-all-options) section above (set `AWS_PROFILE` locally, or run `scripts/aws-sso-to-env.sh` in Codespaces).
 
 ```console
 # Duplicate example `.env` file, then set your AWS credentials in it.
@@ -175,7 +180,7 @@ This creates the local SQLite metadata database (including the `task_instance` t
 
 #### 3. Configure environment variables
 
-Prior to configuring environment variables, you'll need to configure (use `aws configure sso`) and be authenticated to AWS with a profile (use `aws sso login --profile <your-aws-profile>`) that has read access to the Secrets Manager secrets under `airflow/connections/` and `airflow/variables/`. You can use the `dpe-prod` AWS account. [See configuration docs for more info.](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html#sso-configure-profile-token-auto-sso).
+Prior to configuring environment variables, configure and log in to an SSO profile with read access to the `dpe-prod` Secrets Manager secrets (`airflow/connections/`, `airflow/variables/`) — see [AWS credentials](#aws-credentials-required-for-all-options) for the one-time setup and `aws sso login` step. Unlike the container paths, here you point Airflow's secrets backend at the profile directly (below) rather than via `.env`.
 
 Set the following exports (e.g., in your shell profile) so Airflow can resolve connections and variables from AWS Secrets Manager and deserialize custom dataclasses passed between tasks:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -72,7 +72,11 @@ x-airflow-common:
     # The following line can be used to set a custom config file, stored in the local config folder
     # If you want to use it, outcomment it and replace airflow.cfg with the name of your config file
     # AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'
-      # Passing through AWS credentials
+      # AWS credentials. Two mutually-exclusive ways to authenticate (see .env.example):
+      #   1. AWS_PROFILE + a mounted ~/.aws (SSO profile, auto-refreshes tokens)
+      #   2. Exported short-lived AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN
+    AWS_PROFILE: ${AWS_PROFILE:-}
+    AWS_REGION: ${AWS_REGION:-us-east-1}
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
     AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
@@ -84,6 +88,10 @@ x-airflow-common:
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
     - ${AIRFLOW_PROJ_DIR:-.}/config/airflow.cfg:/opt/airflow/airflow.cfg #mounts airflow.cfg
     - ${AIRFLOW_PROJ_DIR:-.}/src:/opt/airflow/src #mounts src/ for custom modules
+    # Read-only mount of the host AWS config so an SSO profile (AWS_PROFILE) works
+    # inside the containers. Must be an absolute path (Compose does not expand '~').
+    # Points at a throwaway path when unused (e.g. Codespaces export path).
+    - ${HOST_AWS_DIR:-${HOME}/.aws}:/home/airflow/.aws:ro
   user: "${AIRFLOW_UID:-50000}:0"
   depends_on:
     &airflow-common-depends-on

--- a/scripts/aws-sso-to-env.sh
+++ b/scripts/aws-sso-to-env.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Log in via AWS SSO and export short-lived credentials into .env for docker compose.
+# Log in via AWS SSO and write short-lived credentials into .env for docker compose.
 # Usage: bash scripts/aws-sso-to-env.sh <your-sso-profile>
+# Only the AWS credential lines are touched; all other .env content is left intact.
 # Credentials are short-lived; re-run this script to refresh them.
 set -euo pipefail
 
@@ -14,11 +15,22 @@ ENV_FILE="$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.env"
 
 aws sso login --profile "${PROFILE}"
 
-# Strip any previously exported AWS keys, then append the current ones.
-if [[ -f "${ENV_FILE}" ]]; then
-  grep -vE '^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN)=' "${ENV_FILE}" > "${ENV_FILE}.tmp"
-  mv "${ENV_FILE}.tmp" "${ENV_FILE}"
-fi
-aws configure export-credentials --profile "${PROFILE}" --format env-no-export >> "${ENV_FILE}"
+# Fetch the credentials first, so a failure here never mutates the user's .env.
+CREDS="$(aws configure export-credentials --profile "${PROFILE}" --format env-no-export)"
 
-echo "Wrote short-lived AWS credentials for profile '${PROFILE}' to ${ENV_FILE}"
+touch "${ENV_FILE}"
+
+# Upsert each credential line in place: replace an existing assignment, or append
+# it if absent. Every other line in .env is preserved untouched.
+while IFS= read -r line; do
+  key="${line%%=*}"
+  [[ -z "${key}" ]] && continue
+  if grep -qE "^${key}=" "${ENV_FILE}"; then
+    # Use a non-/ delimiter since credential values contain '/'.
+    sed -i "s|^${key}=.*|${line}|" "${ENV_FILE}"
+  else
+    printf '%s\n' "${line}" >> "${ENV_FILE}"
+  fi
+done <<< "${CREDS}"
+
+echo "Updated AWS credentials for profile '${PROFILE}' in ${ENV_FILE}"

--- a/scripts/aws-sso-to-env.sh
+++ b/scripts/aws-sso-to-env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Log in via AWS SSO and export short-lived credentials into .env for docker compose.
+# Usage: bash scripts/aws-sso-to-env.sh <your-sso-profile>
+# Credentials are short-lived; re-run this script to refresh them.
+set -euo pipefail
+
+PROFILE="${1:-${AWS_PROFILE:-}}"
+if [[ -z "${PROFILE}" ]]; then
+  echo "Usage: bash scripts/aws-sso-to-env.sh <your-sso-profile>" >&2
+  exit 1
+fi
+
+ENV_FILE="$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.env"
+
+aws sso login --profile "${PROFILE}"
+
+# Strip any previously exported AWS keys, then append the current ones.
+if [[ -f "${ENV_FILE}" ]]; then
+  grep -vE '^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN)=' "${ENV_FILE}" > "${ENV_FILE}.tmp"
+  mv "${ENV_FILE}.tmp" "${ENV_FILE}"
+fi
+aws configure export-credentials --profile "${PROFILE}" --format env-no-export >> "${ENV_FILE}"
+
+echo "Wrote short-lived AWS credentials for profile '${PROFILE}' to ${ENV_FILE}"


### PR DESCRIPTION
# **Problem:**

Local development authenticates to AWS Secrets Manager (`dpe-prod`) using a **shared** `airflow-secrets-backend` IAM access key, fanned out as GitHub Codespace secrets and injected into the docker-compose stack as `AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN`. That key must be manually rotated every 90 days for CIS 1.14 ([IT-4153](https://sagebionetworks.jira.com/browse/IT-4153)), and a shared long-lived key handed to every developer is itself a security smell.

# **Solution:**

Developers authenticate with their **own** AWS Identity Center (SSO) credentials — the existing `dpe-prod` `Developer` permission set — so there is no shared key to rotate. The secrets backend uses boto3's default credential chain, so SSO-derived credentials resolve transparently.

- **`docker-compose.yaml`**: add `AWS_PROFILE` / `AWS_REGION` passthrough and an optional read-only `~/.aws` mount (`${HOST_AWS_DIR:-${HOME}/.aws}` → `/home/airflow/.aws`), while keeping the existing exported-credential passthrough. Two supported paths:
  - **Local Dev Container / VS Code** — set `AWS_PROFILE` (+ `HOST_AWS_DIR` if needed); the mounted profile auto-refreshes SSO tokens.
  - **Codespaces** — `aws sso login`, then `bash scripts/aws-sso-to-env.sh <profile>` writes short-lived creds into `.env`.
- **`scripts/aws-sso-to-env.sh`** (new): logs in via SSO and exports short-lived credentials into `.env` (strips any stale ones first).
- **`.env.example`**: two labeled, mutually-exclusive credential blocks.
- **`README.md` / `CONTRIBUTING.md`**: new "AWS credentials" section documenting the one-time `aws configure sso` setup and both delivery paths; Secrets + Troubleshooting sections rewritten for SSO; removed the shared-IAM-user / manual-90-day-rotation guidance and the Confluence rotation-runbook link.

Codespaces remains supported — just SSO-authenticated per developer rather than relying on injected shared-key secrets.

# **Testing:**

- `docker compose config` renders successfully: `AWS_PROFILE` interpolates, `AWS_REGION` defaults to `us-east-1`, and the `~/.aws` mount resolves to an absolute host path mounted read-only at `/home/airflow/.aws` (correct `HOME` for the uid-50000 airflow user).
- `bash -n` syntax check on the helper script; confirmed `aws configure export-credentials --format env-no-export` emits exactly `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` (the vars compose reads).
- Verified README/CONTRIBUTING anchor links resolve; added the new section to the TOC.

Reviewer verification:
1. `aws sso login --profile <p>`; set `AWS_PROFILE` in `.env`; `docker compose up --build --detach`; `./airflow.sh python` → run the boto3 snippet in the README → lists `airflow/connections/*` + `airflow/variables/*` with no `UnrecognizedClientException`.
2. Codespaces path: unset `AWS_PROFILE`; `bash scripts/aws-sso-to-env.sh <p>`; `docker compose up`; same snippet succeeds.

## Note / dependency

Deployed Airflow's keyless access is handled by the companion PR (`eks-stack` #88, `airflow-croissant` IRSA role). The shared `airflow-secrets-backend` key and its Codespace secrets should be deleted only **after both PRs are live and verified** — this PR removes the local dependency on that key; #88 removes the prod dependency.

[IT-4153]: https://sagebionetworks.jira.com/browse/IT-4153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ