### PR TITLE
Refactor all DAGs to use `src.synapse_hook`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          
+
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip
@@ -24,11 +24,15 @@ jobs:
       - name: Install airflow deps
         run: |
           pip install -r requirements-airflow.txt
-          
+
       - name: Run tests
+        env:
+          # Setting the configuration URL for the challenge configs
+          CONFIG_URL: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/${{ github.sha }}/dags/challenge_configs.yaml
         run: |
           python -m pytest tests/ -v --tb=short
-  
+
   ghcr-publish:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,6 +33,10 @@ jobs:
           pip install -r requirements-airflow.txt
 
       - name: Run tests
+        env:
+          # Setting the configuration URL for the challenge configs
+          CONFIG_URL: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/${{ github.sha }}/dags/challenge_configs.yaml
         run: |
           python -m pytest tests/ -v --tb=short
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -669,7 +669,7 @@ Modify everything in `<>` and remove the `<>` when complete:
   bucket_name: "<my-challenge-project-tower-scratch>"
   key: "<10days/my_challenge>"
   dag_config:
-    schedule_interval: "*/1 * * * *"
+    schedule: "*/1 * * * *"
     start_date: "<YYYY>-<MM>-<DD>T<HH>:<MM>:<SS>+00:00" # Will be converted to a UTC datetime object
     end_date: "<YYYY>-<MM>-<DD>T<HH>:<MM>:<SS>+00:00" # Will be converted to a UTC datetime object
     catchup: false
@@ -726,7 +726,7 @@ See below for a list of parameters and their descriptions:
 1. `bucket_name`: The S3 bucket where the challenge-related files (such as CSV manifests) will be stored. Note that the Seqera Platform workspaces can only access the S3 buckets assigned to them.
 1. `key`: The S3 key prefix (or folder path) under which the submissions manifest file is uploaded for a challenge DAG run. At runtime, a unique run-specific UUID is appended to this key to ensure that files are uniquely identified and organized. Since this folder path lives in a scratch bucket, you can leverage one of the folders that are configured to delete stale objects based on a certain number of days ([see here](https://sagebionetworks.jira.com/wiki/spaces/WF/pages/2191556616/Getting+Started+with+Nextflow+and+Seqera+Platform#Tower-Project-Breakdown) for more details). This will affect what value you put here. For example, **if you would like for your manifest file to live for 10 days, use `10days/my_project_folder`**.
 1. `dag_config`: A nested dictionary containing additional DAG scheduling and runtime parameters:
-   * `schedule_interval`: A cron expression that determines how frequently the DAG is triggered.
+   * `schedule`: A cron expression that determines how frequently the DAG is triggered.
    * `start_date`: An ISO 8601–formatted date-time string (e.g. `2025-07-16T08:00:00+02:00`) that tells the DAG factory when to begin scheduling runs. The trailing ±HH:MM UTC-offset makes the datetime timezone-aware, and the factory converts it into a Python datetime object in UTC.
    * `end_date`: An ISO 8601–formatted date-time string (e.g. `2025-07-20T00:00:00-05:00`) that indicates when the DAG should stop scheduling new runs. Like start_date, it may include a ±HH:MM UTC-offset and is parsed by the factory into a timezone-aware Python datetime object in UTC.
    * `catchup`: A Boolean flag that indicates whether Airflow should run missed DAG runs (catch up) if the scheduler falls behind.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -707,6 +707,16 @@ By updating `challenge_configs.yaml` with your **challenge DAG config**, you can
 
 ----
 
+### Local development
+
+By default, `challenge_dag_factory.py` loads `challenge_configs.yaml` from the production (`main`) branch of this repository. To test changes to `challenge_configs.yaml` before they are merged, set the `CONFIG_URL` environment variable to either a local copy of the YAML file or the raw GitHub URL for your feature branch.
+
+For example, to test a feature branch:
+
+```console
+export CONFIG_URL="https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/<YOUR_BRANCH>/dags/challenge_configs.yaml"
+```
+
 ### Creating Your Challenge DAG Config
 
 Each challenge DAG config will have its own set of parameters depending on the customized workflow profile on [nf-synapse-challenge](https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/blob/main/nextflow.config) and what part of Synapse and AWS S3 the workflow will

--- a/archived_dags/cavatica-launch-poc-v2.py
+++ b/archived_dags/cavatica-launch-poc-v2.py
@@ -15,7 +15,7 @@ params = {
 
 dag_args: dict[str, Any]
 dag_args = {
-    "schedule_interval": None,
+    "schedule": None,
     "start_date": datetime(2023, 1, 1),
     "catchup": False,
     "default_args": {

--- a/archived_dags/htan-nf_dcqc_dag.py
+++ b/archived_dags/htan-nf_dcqc_dag.py
@@ -16,7 +16,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": None,
+    "schedule": None,
     "start_date": datetime(2023, 6, 1),
     "catchup": False,
     "default_args": {

--- a/config/airflow.cfg
+++ b/config/airflow.cfg
@@ -1071,7 +1071,7 @@ dag_stale_not_seen_duration = 600
 use_job_schedule = True
 
 # Allow externally triggered DagRuns for Execution Dates in the future
-# Only has effect if schedule_interval is set to None in DAG
+# Only has effect if schedule is set to None in DAG
 allow_trigger_in_future = False
 
 # How often to check for expired trigger requests that have not run yet.

--- a/dags/agora_nf.py
+++ b/dags/agora_nf.py
@@ -41,9 +41,9 @@ from airflow.models.dag import DAG
 from airflow.models.param import Param
 from orca.services.nextflowtower import NextflowTowerHook
 from orca.services.nextflowtower.models import LaunchInfo
-from orca.services.synapse import SynapseHook
 from slack_sdk import WebClient
 
+from src.synapse_hook import SynapseHook
 from src.utils import validate_required_secrets
 
 

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -16,20 +16,18 @@ The DAG runs monthly and uses Airflow Variables for configuration.
 
 from datetime import datetime
 import requests
-from typing import Dict, List, Tuple, Any, Optional
-
-import pandas as pd
 import json
-from jsonata import jsonata
-from jsonschema import validate, ValidationError
-
-from synapseclient.models import Dataset, DatasetCollection, File
-from orca.services.synapse import SynapseHook
+from typing import Dict, List, Tuple, Any, Optional
 
 from airflow.decorators import task, dag
 from airflow.models import Variable, Param
+from jsonata import jsonata
+from jsonschema import validate, ValidationError
+from synapseclient.models import Dataset, DatasetCollection, File
+import pandas as pd
 from slack_sdk import WebClient
 
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "project_id": Param("syn64892175", type="string"),

--- a/dags/als-kp-dataset-dag.py
+++ b/dags/als-kp-dataset-dag.py
@@ -48,7 +48,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 0 1 * *",  # Run on the first day of the month at midnight
+    "schedule": "0 0 1 * *",  # Run on the first day of the month at midnight
     "start_date": datetime(2025, 5, 1),
     "catchup": False,
     "default_args": {

--- a/dags/challenge-submission-dag.py
+++ b/dags/challenge-submission-dag.py
@@ -19,7 +19,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": None,
+    "schedule": None,
     "start_date": datetime(2023, 6, 1),
     "catchup": False,
     "default_args": {

--- a/dags/challenge-submission-dag.py
+++ b/dags/challenge-submission-dag.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 from airflow.decorators import dag, task
 from airflow.models import Param
-
 from orca.services.nextflowtower import NextflowTowerHook
 from orca.services.nextflowtower.models import LaunchInfo
-from orca.services.synapse import SynapseHook
+
+from src.synapse_hook import SynapseHook
 
 
 dag_params = {

--- a/dags/challenge_configs.yaml
+++ b/dags/challenge_configs.yaml
@@ -9,7 +9,7 @@ olfactory-2025-task1:
   bucket_name: "olfactory-challenge-project-tower-scratch"
   key: "10days/olfactory_challenge_task1"
   dag_config:
-    schedule_interval: "*/3 * * * *"
+    schedule: "*/3 * * * *"
     start_date: "2024-04-09T00:00:00+00:00"
     end_date: "2025-07-21T23:59:59+00:00"
     catchup: false
@@ -29,7 +29,7 @@ olfactory-2025-task2:
   bucket_name: "olfactory-challenge-project-tower-scratch"
   key: "10days/olfactory_challenge_task2"
   dag_config:
-    schedule_interval: "*/3 * * * *"
+    schedule: "*/3 * * * *"
     start_date: "2024-04-09T00:00:00+00:00"
     end_date: "2025-07-21T23:59:59+00:00"
     catchup: false
@@ -49,7 +49,7 @@ final-olfactory-2025-task1:
   bucket_name: "olfactory-challenge-project-tower-scratch"
   key: "10days/final_olfactory_challenge_task1"
   dag_config:
-    schedule_interval: "*/3 * * * *"
+    schedule: "*/3 * * * *"
     start_date: "2025-07-16T00:00:00+00:00"
     end_date: "2025-08-08T23:59:00+00:00"
     catchup: false
@@ -69,7 +69,7 @@ final-olfactory-2025-task2:
   bucket_name: "olfactory-challenge-project-tower-scratch"
   key: "10days/final_olfactory_challenge_task2"
   dag_config:
-    schedule_interval: "*/3 * * * *"
+    schedule: "*/3 * * * *"
     start_date: "2025-07-16T00:00:00+00:00"
     end_date: "2025-08-08T23:59:00+00:00"
     catchup: false

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -95,7 +95,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     
     # Start with default configuration
     dag_config = {
-        "schedule_interval": "*/3 * * * *",
+        "schedule": "*/3 * * * *",
         "start_date": datetime(2024, 4, 9, tzinfo=timezone.utc),
         "catchup": False,
         "default_args": {"retries": 2},
@@ -213,7 +213,7 @@ def create_challenge_dag(challenge_name: str, config: dict):
         @task
         def get_new_submissions(**context):
             hook = SynapseHook(context["params"]["synapse_conn_id"])
-            submissions = hook.ops.get_submissions_with_status(
+            submissions = hook.get_submissions_with_status(
                 context["params"]["tower_view_id"], "RECEIVED"
             )
 
@@ -230,7 +230,7 @@ def create_challenge_dag(challenge_name: str, config: dict):
             if submissions:
                 hook = SynapseHook(context["params"]["synapse_conn_id"])
                 for submission in submissions:
-                    hook.ops.update_submission_status(
+                    hook.update_submission_status(
                         submission_id=submission, submission_status="EVALUATION_IN_PROGRESS"
                     )
                 return "stage_submissions_manifest"

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -18,8 +18,14 @@ from src.synapse_hook import SynapseHook
 
 
 # Define the path to your challenge configuration file.
-CONFIG_URL = "https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/main/dags/challenge_configs.yaml"
-
+CONFIG_URL = os.environ.get(
+    "CONFIG_URL",
+    (
+        "https://raw.githubusercontent.com/"
+        "Sage-Bionetworks-Workflows/orca-recipes/main/"
+        "dags/challenge_configs.yaml"
+    ),
+)
 
 def load_challenge_configs(url=CONFIG_URL):
     """Load challenge configurations from a raw GitHub URL."""
@@ -74,8 +80,8 @@ def enforce_utc_timezone(dag_config: dict):
 
             # Enforce UTC timezone
             dag_config[param] = dt.astimezone(timezone.utc)
-        
-    
+
+
 def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> dict:
     """
     Return the DAG configuration for a challenge.
@@ -92,7 +98,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     Returns:
         dict: The resolved DAG configuration.
     """
-    
+
     # Start with default configuration
     dag_config = {
         "schedule": "*/3 * * * *",
@@ -106,10 +112,10 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     # Update with any custom configuration if provided
     if config.get('dag_config'):
         dag_config.update(config['dag_config'])
-        
+
         # Ensure start_date/end_date is a datetime object in UTC
         enforce_utc_timezone(dag_config)
-            
+
         # Ensure challenge name is in tags
         if 'tags' in dag_config:
             if challenge_name not in dag_config['tags']:
@@ -264,7 +270,7 @@ def create_challenge_dag(challenge_name: str, config: dict):
 
             # Encode the data to bytes for the s3 upload
             submissions_bytes = submissions_content.encode("utf-8")
-            
+
             # Create a bytes bufferobject
             bytes_buffer = io.BytesIO(submissions_bytes)
 

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -11,10 +11,11 @@ from airflow.models import Param, DagRun
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.utils.session import create_session
 from airflow.utils.state import State
-
 from orca.services.nextflowtower import NextflowTowerHook
 from orca.services.nextflowtower.models import LaunchInfo
-from orca.services.synapse import SynapseHook
+
+from src.synapse_hook import SynapseHook
+
 
 # Define the path to your challenge configuration file.
 CONFIG_URL = "https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/main/dags/challenge_configs.yaml"

--- a/dags/genie/genie-nf-validate.py
+++ b/dags/genie/genie-nf-validate.py
@@ -22,7 +22,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 5,17 * * *",
+    "schedule": "0 5,17 * * *",
     "start_date": datetime(2023, 2, 21),
     "catchup": False,
     "default_args": {

--- a/dags/genie/genie-patient-sample-tracking-dag.py
+++ b/dags/genie/genie-patient-sample-tracking-dag.py
@@ -126,7 +126,7 @@ def validate_patient_sample_results(
 
 
 @dag(
-    schedule_interval="0 1 28 * *", # run on the 28th of each month
+    schedule="0 1 28 * *", # run on the 28th of each month
     start_date=datetime(2025, 1, 1),
     catchup=False,
     default_args={"retries": 1},

--- a/dags/genie/genie-patient-sample-tracking-dag.py
+++ b/dags/genie/genie-patient-sample-tracking-dag.py
@@ -7,9 +7,10 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
 from airflow.utils.db import provide_session
 from airflow.models import XCom
+
+from src.synapse_hook import SynapseHook
 
 logger = logging.getLogger(__name__)
 

--- a/dags/portal-data-to-snowflake-dag.py
+++ b/dags/portal-data-to-snowflake-dag.py
@@ -26,7 +26,7 @@ portal_dict = {
         }
 
 dag_config = {
-    "schedule_interval": "0 0 * * 1",
+    "schedule": "0 0 * * 1",
     "start_date": datetime(2024, 1, 10),
     "catchup": False,
     "default_args": {

--- a/dags/portal-data-to-snowflake-dag.py
+++ b/dags/portal-data-to-snowflake-dag.py
@@ -5,8 +5,9 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
 from snowflake.connector.pandas_tools import write_pandas
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param(

--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -23,7 +23,7 @@ dag_params = {
 
 dag_config = {
     # run on the 2nd of every month at midnight
-    "schedule_interval": "0 0 2 * *",
+    "schedule": "0 0 2 * *",
     "start_date": datetime(2024, 7, 1),
     "catchup": False,
     "default_args": {

--- a/dags/synapse-by-the-numbers-dag.py
+++ b/dags/synapse-by-the-numbers-dag.py
@@ -11,7 +11,8 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -69,7 +69,6 @@ from opentelemetry.sdk.trace import Tracer, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.trace.propagation.tracecontext import \
     TraceContextTextMapPropagator
-from orca.services.synapse import SynapseHook
 from pandas import DataFrame
 from synapseclient import Entity, Synapse, Table
 from synapseclient.core.exceptions import (SynapseAuthenticationError,
@@ -77,6 +76,8 @@ from synapseclient.core.exceptions import (SynapseAuthenticationError,
 from synapseclient.core.retry import with_retry
 from synapseclient.models import File
 from synapseclient.core.utils import delete_none_keys
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),

--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -93,7 +93,7 @@ dag_params = {
 
 dag_config = {
     # Every Monday
-    "schedule_interval": "0 0 * * 1",
+    "schedule": "0 0 * * 1",
     "start_date": datetime(2025, 2, 1),
     "catchup": False,
     "max_active_tasks": 4,

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -24,8 +24,9 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
 from slack_sdk import WebClient
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),

--- a/dags/synapse-datasets-created-7-days.py
+++ b/dags/synapse-datasets-created-7-days.py
@@ -40,7 +40,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 0 * * 1",
+    "schedule": "0 0 * * 1",
     "start_date": datetime(2025, 2, 1),
     "catchup": False,
     "default_args": {

--- a/dags/synapse_dataset_to_croissant_minimal.py
+++ b/dags/synapse_dataset_to_croissant_minimal.py
@@ -72,7 +72,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 0 * * 1",
+    "schedule": "0 0 * * 1",
     "start_date": datetime(2025, 2, 1),
     "catchup": False,
     "default_args": {

--- a/dags/synapse_dataset_to_croissant_minimal.py
+++ b/dags/synapse_dataset_to_croissant_minimal.py
@@ -32,7 +32,6 @@ from synapseclient.models import query
 from synapseclient import Entity, Synapse
 from synapseclient.models import Table
 from airflow.models.param import Param
-from orca.services.synapse import SynapseHook
 import pandas as pd
 from pandas import DataFrame
 from urllib.parse import quote_plus
@@ -60,6 +59,8 @@ from opentelemetry.sdk.trace import Tracer, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from synapseclient.core.retry import with_retry
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),

--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -21,7 +21,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 0 * * *",
+    "schedule": "0 0 * * *",
     "start_date": datetime(2024, 4, 1),
     "catchup": False,
     "default_args": {

--- a/dags/top-public-synapse-projects-30-days-from-snowflake.py
+++ b/dags/top-public-synapse-projects-30-days-from-snowflake.py
@@ -11,7 +11,8 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -19,7 +19,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 0 1 * *",
+    "schedule": "0 0 1 * *",
     "start_date": datetime(2024, 4, 1),
     "catchup": False,
     "default_args": {

--- a/dags/top-public-synapse-projects-all-time-from-snowflake.py
+++ b/dags/top-public-synapse-projects-all-time-from-snowflake.py
@@ -10,7 +10,8 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+
+from src.synapse_hook import SynapseHook
 
 dag_params = {
     "snowflake_developer_service_conn": Param("SNOWFLAKE_DEVELOPER_SERVICE_RAW_CONN", type="string"),

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -44,7 +44,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 18 * * *",
+    "schedule": "0 18 * * *",
     "start_date": datetime(2024, 2, 20),
     "catchup": False,
     "default_args": {

--- a/dags/top-public-synapse-projects-from-snowflake.py
+++ b/dags/top-public-synapse-projects-from-snowflake.py
@@ -19,9 +19,11 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
 from slack_sdk import WebClient
 import json
+
+from src.synapse_hook import SynapseHook
+
 
 dag_params = {
     "snowflake_developer_service_conn": Param(

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -37,7 +37,7 @@ dag_params = {
 
 dag_config = {
     # run on the 2nd of every month at midnight
-    "schedule_interval": "0 0 2 * *",
+    "schedule": "0 0 2 * *",
     "start_date": datetime(2024, 1, 1),
     "catchup": False,
     "default_args": {

--- a/dags/trending-projects-snapshot-dag.py
+++ b/dags/trending-projects-snapshot-dag.py
@@ -21,7 +21,8 @@ import synapseclient
 from airflow.decorators import dag, task
 from airflow.models.param import Param
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from orca.services.synapse import SynapseHook
+
+from src.synapse_hook import SynapseHook
 
 
 SYNAPSE_RESULTS_TABLE = "syn61597055"

--- a/template_dags/dcqc-poc-dag.py
+++ b/template_dags/dcqc-poc-dag.py
@@ -42,7 +42,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": "0 0 * * *",
+    "schedule": "0 0 * * *",
     "start_date": datetime(2023, 6, 1),
     "catchup": False,
     "default_args": {

--- a/template_dags/nextflow-launch-poc-dag.py
+++ b/template_dags/nextflow-launch-poc-dag.py
@@ -20,7 +20,7 @@ dag_params = {
 }
 
 dag_config = {
-    "schedule_interval": None,
+    "schedule": None,
     "start_date": datetime(2023, 6, 1),
     "catchup": False,
     "default_args": {

--- a/template_dags/synapse-webhook-poc-dag.py
+++ b/template_dags/synapse-webhook-poc-dag.py
@@ -60,7 +60,7 @@ dag_params = {
 
 
 @dag(
-    schedule_interval="*/15 * * * *",  # Run every 15 minutes
+    schedule="*/15 * * * *",  # Run every 15 minutes
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={

--- a/tests/dags/test_all_dags.py
+++ b/tests/dags/test_all_dags.py
@@ -1,0 +1,150 @@
+"""Unit/structural tests for all DAGs.
+
+These tests import DAGs in a separate subprocess to mimic Airflow's import
+environment as closely as possible. Running `DagBag` directly in the pytest
+process inherits pytest's `sys.path`, which includes the repository root and
+can mask import issues that would fail when Airflow parses DAGs.
+
+For example, this incorrect import succeeds under `python -m pytest` because
+the repository root is on `sys.path`:
+
+    from dags.src.utils ...
+
+However, Airflow imports DAGs relative to the configured DAG folder, so the
+correct import is:
+
+    from src.utils ...
+
+Using a fresh subprocess allows us to control PYTHONPATH and the working
+directory so DAG imports behave the same way they do when parsed by Airflow.
+"""
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DAG_FOLDER = REPO_ROOT / "dags"
+DAG_FILES = sorted(DAG_FOLDER.rglob("*.py"))
+
+# DAGs that read Airflow Variables/Connections at parse time and therefore
+# cannot be import validated without those secrets present in the environment.
+KNOWN_PARSE_TIME_DEPENDENCIES: set[str] = {
+    "synapse-dataset-to-croissant.py",
+    "synapse_dataset_to_croissant_minimal.py",
+}
+
+def _parse_dags_like_airflow() -> Dict[str, dict]:
+    """Parse every DAG in a subprocess with only the dags/ folder on sys.path.
+
+    Returns:
+        Dict[str, dict]: A dictionary containing import errors and DAG information
+    """
+    # Marker prefixed onto the subprocess's JSON result line so we can pick it
+    # out of stdout even if Airflow logs other noise.
+    result_marker = "__DAGBAG_RESULT__"
+
+    # Script run in the subprocess: build a DagBag over the whole folder with an
+    # Airflow-style sys.path and emit import errors + discovered dag ids as one
+    # JSON line
+    dagbag_parse_script = textwrap.dedent(
+        f"""
+        import json, sys
+        from airflow.models import DagBag
+
+        bag = DagBag(dag_folder=sys.argv[1], include_examples=False)
+        print({result_marker!r} + json.dumps({{
+            "import_errors": {{str(k): str(v) for k, v in bag.import_errors.items()}},
+            "dags": {{
+                dag_id: {{
+                    "num_tasks": len(dag.tasks),
+                    "tags": sorted(dag.tags or []),
+                }}
+                for dag_id, dag in bag.dags.items()
+            }},
+        }}))
+        """
+    )
+
+    env = dict(os.environ)
+   # Mimic Airflow's runtime by exposing only the DAGs folder on PYTHONPATH,
+    # preventing accidental imports from the repository root
+    env["PYTHONPATH"] = str(DAG_FOLDER)
+    env["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
+
+    result = subprocess.run(
+        [sys.executable, "-c", dagbag_parse_script, str(DAG_FOLDER)],
+        capture_output=True,
+        text=True,
+        # Set the working directory to dags/ so Python's implicit -c path entry
+        # does not expose the repository root
+        cwd=str(DAG_FOLDER),
+        env=env,
+    )
+
+    marker_lines = [
+        line[len(result_marker):]
+        for line in result.stdout.splitlines()
+        if line.startswith(result_marker)
+    ]
+    assert marker_lines, (
+        "DAG parsing subprocess produced no result.\n"
+        f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )
+    return json.loads(marker_lines[-1])
+
+
+# Parsed once at collection time, keys of import_errors are absolute file paths.
+_PARSE_RESULT = _parse_dags_like_airflow()
+_IMPORT_ERRORS = {
+    str(Path(path).resolve().relative_to(DAG_FOLDER.resolve())): error
+    for path, error in _PARSE_RESULT["import_errors"].items()
+}
+
+@pytest.mark.parametrize(
+    "dag_file",
+    DAG_FILES,
+    ids=lambda path: str(path.relative_to(DAG_FOLDER)),
+)
+def test_all_dag_imports_successfully(dag_file):
+    """Tests that each DAG file imports cleanly under Airflow's runtime sys.path"""
+    relative_path = str(dag_file.relative_to(DAG_FOLDER))
+
+    if dag_file.name in KNOWN_PARSE_TIME_DEPENDENCIES:
+        pytest.skip(
+            f"{relative_path} is an allowlisted parse-time-dependent DAG"
+        )
+
+    error = _IMPORT_ERRORS.get(relative_path)
+
+    assert error is None, (
+        f"Import error in {relative_path}:\n{error}"
+    )
+
+
+def test_no_stale_parse_time_dependency_allowlist():
+    """Allowlisted DAGs must still actually fail, or the entry is stale"""
+    stale = KNOWN_PARSE_TIME_DEPENDENCIES - set(_IMPORT_ERRORS)
+    assert not stale, (
+        "These DAGs are allowlisted for parse-time failures but no longer fail. "
+        f"Remove them from KNOWN_PARSE_TIME_DEPENDENCIES: {stale}"
+    )
+
+
+@pytest.mark.parametrize("dag_id", sorted(_PARSE_RESULT["dags"]))
+def test_all_dag_has_tasks(dag_id):
+    """Each DAG defines at least one task."""
+    assert _PARSE_RESULT["dags"][dag_id]["num_tasks"] >= 1, (
+        f"DAG '{dag_id}' has no tasks"
+    )
+
+@pytest.mark.skip(reason="Skipping tag tests for now until we establish a tagging convention")
+@pytest.mark.parametrize("dag_id", sorted(_PARSE_RESULT["dags"]))
+def test_all_dag_has_tags(dag_id):
+    """Each DAG declares at least one tag."""
+    assert _PARSE_RESULT["dags"][dag_id]["tags"], f"DAG '{dag_id}' has no tags"

--- a/tests/dags/test_zenodo_tep_metrics_dag.py
+++ b/tests/dags/test_zenodo_tep_metrics_dag.py
@@ -460,12 +460,6 @@ def dagbag():
     return DagBag(dag_folder="dags/zenodo_tep_metrics_dag.py", include_examples=False)
 
 
-def test_dag_loads_with_no_issues(dagbag):
-    assert dagbag.import_errors == {}
-    dag = dagbag.dags["zenodo_tep_metrics_dag"]
-    assert dag is not None
-
-
 def test_dag_structure_is_correct(dagbag):
     # Read from the parsed .dags dict (get_dag() hits the Airflow metadata DB,
     # which isn't available in CI).


### PR DESCRIPTION
# **Problem:**
We are looking to deprecate `py-orca` to reduce maintenance

# **Solution:**
1. Implement dags with `src.synapse_hook`
2. Bonus: prep for airflow 3 and convert `schedule_interval` to `schedule`

# **Testing:**
NA

depends on #175 
