### PR TITLE
[DPE-1764, DPE-1755] Add test suite to test all dags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          
+
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip
@@ -24,11 +24,15 @@ jobs:
       - name: Install airflow deps
         run: |
           pip install -r requirements-airflow.txt
-          
+
       - name: Run tests
+        env:
+          # Setting the configuration URL for the challenge configs
+          CONFIG_URL: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/${{ github.sha }}/dags/challenge_configs.yaml
         run: |
           python -m pytest tests/ -v --tb=short
-  
+
   ghcr-publish:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,8 +34,9 @@ jobs:
 
       - name: Run tests
         env:
-         CONFIG_URL: >-
-           https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/${{ github.sha }}/dags/challenge_configs.yaml
+          # Setting the configuration URL for the challenge configs
+          CONFIG_URL: >-
+            https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/${{ github.sha }}/dags/challenge_configs.yaml
         run: |
           python -m pytest tests/ -v --tb=short
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,6 +33,9 @@ jobs:
           pip install -r requirements-airflow.txt
 
       - name: Run tests
+        env:
+         CONFIG_URL: >-
+           https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/${{ github.sha }}/dags/challenge_configs.yaml
         run: |
           python -m pytest tests/ -v --tb=short
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -707,6 +707,16 @@ By updating `challenge_configs.yaml` with your **challenge DAG config**, you can
 
 ----
 
+### Local development
+
+By default, `challenge_dag_factory.py` loads `challenge_configs.yaml` from the production (`main`) branch of this repository. To test changes to `challenge_configs.yaml` before they are merged, set the `CONFIG_URL` environment variable to either a local copy of the YAML file or the raw GitHub URL for your feature branch.
+
+For example, to test a feature branch:
+
+```console
+export CONFIG_URL="https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/<YOUR_BRANCH>/dags/challenge_configs.yaml"
+```
+
 ### Creating Your Challenge DAG Config
 
 Each challenge DAG config will have its own set of parameters depending on the customized workflow profile on [nf-synapse-challenge](https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/blob/main/nextflow.config) and what part of Synapse and AWS S3 the workflow will

--- a/dags/challenge_dag_factory.py
+++ b/dags/challenge_dag_factory.py
@@ -18,8 +18,14 @@ from src.synapse_hook import SynapseHook
 
 
 # Define the path to your challenge configuration file.
-CONFIG_URL = "https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/orca-recipes/main/dags/challenge_configs.yaml"
-
+CONFIG_URL = os.environ.get(
+    "CONFIG_URL",
+    (
+        "https://raw.githubusercontent.com/"
+        "Sage-Bionetworks-Workflows/orca-recipes/main/"
+        "dags/challenge_configs.yaml"
+    ),
+)
 
 def load_challenge_configs(url=CONFIG_URL):
     """Load challenge configurations from a raw GitHub URL."""
@@ -74,8 +80,8 @@ def enforce_utc_timezone(dag_config: dict):
 
             # Enforce UTC timezone
             dag_config[param] = dt.astimezone(timezone.utc)
-        
-    
+
+
 def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> dict:
     """
     Return the DAG configuration for a challenge.
@@ -92,7 +98,7 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     Returns:
         dict: The resolved DAG configuration.
     """
-    
+
     # Start with default configuration
     dag_config = {
         "schedule": "*/3 * * * *",
@@ -106,10 +112,10 @@ def resolve_dag_config(challenge_name: str, dag_params: dict, config: dict) -> d
     # Update with any custom configuration if provided
     if config.get('dag_config'):
         dag_config.update(config['dag_config'])
-        
+
         # Ensure start_date/end_date is a datetime object in UTC
         enforce_utc_timezone(dag_config)
-            
+
         # Ensure challenge name is in tags
         if 'tags' in dag_config:
             if challenge_name not in dag_config['tags']:
@@ -264,7 +270,7 @@ def create_challenge_dag(challenge_name: str, config: dict):
 
             # Encode the data to bytes for the s3 upload
             submissions_bytes = submissions_content.encode("utf-8")
-            
+
             # Create a bytes bufferobject
             bytes_buffer = io.BytesIO(submissions_bytes)
 

--- a/tests/dags/test_all_dags.py
+++ b/tests/dags/test_all_dags.py
@@ -1,4 +1,22 @@
-"""Unit/structural tests for all DAGs
+"""Unit/structural tests for all DAGs.
+
+These tests import DAGs in a separate subprocess to mimic Airflow's import
+environment as closely as possible. Running `DagBag` directly in the pytest
+process inherits pytest's `sys.path`, which includes the repository root and
+can mask import issues that would fail when Airflow parses DAGs.
+
+For example, this incorrect import succeeds under `python -m pytest` because
+the repository root is on `sys.path`:
+
+    from dags.src.utils ...
+
+However, Airflow imports DAGs relative to the configured DAG folder, so the
+correct import is:
+
+    from src.utils ...
+
+Using a fresh subprocess allows us to control PYTHONPATH and the working
+directory so DAG imports behave the same way they do when parsed by Airflow.
 """
 import json
 import os

--- a/tests/dags/test_all_dags.py
+++ b/tests/dags/test_all_dags.py
@@ -1,0 +1,132 @@
+"""Unit/structural tests for all DAGs
+"""
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DAG_FOLDER = REPO_ROOT / "dags"
+DAG_FILES = sorted(DAG_FOLDER.rglob("*.py"))
+
+# DAGs that read Airflow Variables/Connections at parse time and therefore
+# cannot be import validated without those secrets present in the environment.
+KNOWN_PARSE_TIME_DEPENDENCIES: set[str] = {
+    "synapse-dataset-to-croissant.py",
+    "synapse_dataset_to_croissant_minimal.py",
+}
+
+def _parse_dags_like_airflow() -> Dict[str, dict]:
+    """Parse every DAG in a subprocess with only the dags/ folder on sys.path.
+
+    Returns:
+        Dict[str, dict]: A dictionary containing import errors and DAG information
+    """
+    # Marker prefixed onto the subprocess's JSON result line so we can pick it
+    # out of stdout even if Airflow logs other noise.
+    result_marker = "__DAGBAG_RESULT__"
+
+    # Script run in the subprocess: build a DagBag over the whole folder with an
+    # Airflow-style sys.path and emit import errors + discovered dag ids as one
+    # JSON line
+    dagbag_parse_script = textwrap.dedent(
+        f"""
+        import json, sys
+        from airflow.models import DagBag
+
+        bag = DagBag(dag_folder=sys.argv[1], include_examples=False)
+        print({result_marker!r} + json.dumps({{
+            "import_errors": {{str(k): str(v) for k, v in bag.import_errors.items()}},
+            "dags": {{
+                dag_id: {{
+                    "num_tasks": len(dag.tasks),
+                    "tags": sorted(dag.tags or []),
+                }}
+                for dag_id, dag in bag.dags.items()
+            }},
+        }}))
+        """
+    )
+
+    env = dict(os.environ)
+   # Mimic Airflow's runtime by exposing only the DAGs folder on PYTHONPATH,
+    # preventing accidental imports from the repository root
+    env["PYTHONPATH"] = str(DAG_FOLDER)
+    env["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
+
+    result = subprocess.run(
+        [sys.executable, "-c", dagbag_parse_script, str(DAG_FOLDER)],
+        capture_output=True,
+        text=True,
+        # Set the working directory to dags/ so Python's implicit -c path entry
+        # does not expose the repository root
+        cwd=str(DAG_FOLDER),
+        env=env,
+    )
+
+    marker_lines = [
+        line[len(result_marker):]
+        for line in result.stdout.splitlines()
+        if line.startswith(result_marker)
+    ]
+    assert marker_lines, (
+        "DAG parsing subprocess produced no result.\n"
+        f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )
+    return json.loads(marker_lines[-1])
+
+
+# Parsed once at collection time, keys of import_errors are absolute file paths.
+_PARSE_RESULT = _parse_dags_like_airflow()
+_IMPORT_ERRORS = {
+    str(Path(path).resolve().relative_to(DAG_FOLDER.resolve())): error
+    for path, error in _PARSE_RESULT["import_errors"].items()
+}
+
+@pytest.mark.parametrize(
+    "dag_file",
+    DAG_FILES,
+    ids=lambda path: str(path.relative_to(DAG_FOLDER)),
+)
+def test_all_dag_imports_successfully(dag_file):
+    """Tests that each DAG file imports cleanly under Airflow's runtime sys.path"""
+    relative_path = str(dag_file.relative_to(DAG_FOLDER))
+
+    if dag_file.name in KNOWN_PARSE_TIME_DEPENDENCIES:
+        pytest.skip(
+            f"{relative_path} is an allowlisted parse-time-dependent DAG"
+        )
+
+    error = _IMPORT_ERRORS.get(relative_path)
+
+    assert error is None, (
+        f"Import error in {relative_path}:\n{error}"
+    )
+
+
+def test_no_stale_parse_time_dependency_allowlist():
+    """Allowlisted DAGs must still actually fail, or the entry is stale"""
+    stale = KNOWN_PARSE_TIME_DEPENDENCIES - set(_IMPORT_ERRORS)
+    assert not stale, (
+        "These DAGs are allowlisted for parse-time failures but no longer fail. "
+        f"Remove them from KNOWN_PARSE_TIME_DEPENDENCIES: {stale}"
+    )
+
+
+@pytest.mark.parametrize("dag_id", sorted(_PARSE_RESULT["dags"]))
+def test_all_dag_has_tasks(dag_id):
+    """Each DAG defines at least one task."""
+    assert _PARSE_RESULT["dags"][dag_id]["num_tasks"] >= 1, (
+        f"DAG '{dag_id}' has no tasks"
+    )
+
+@pytest.mark.skip(reason="Skipping tag tests for now until we establish a tagging convention")
+@pytest.mark.parametrize("dag_id", sorted(_PARSE_RESULT["dags"]))
+def test_all_dag_has_tags(dag_id):
+    """Each DAG declares at least one tag."""
+    assert _PARSE_RESULT["dags"][dag_id]["tags"], f"DAG '{dag_id}' has no tags"

--- a/tests/dags/test_zenodo_tep_metrics_dag.py
+++ b/tests/dags/test_zenodo_tep_metrics_dag.py
@@ -460,12 +460,6 @@ def dagbag():
     return DagBag(dag_folder="dags/zenodo_tep_metrics_dag.py", include_examples=False)
 
 
-def test_dag_loads_with_no_issues(dagbag):
-    assert dagbag.import_errors == {}
-    dag = dagbag.dags["zenodo_tep_metrics_dag"]
-    assert dag is not None
-
-
 def test_dag_structure_is_correct(dagbag):
     # Read from the parsed .dags dict (get_dag() hits the Airflow metadata DB,
     # which isn't available in CI).


### PR DESCRIPTION
# **Problem:**
We don't have tests that test dag structure/conventions (e.g: dags can be imported, etc)

JIRA Tickets:
- https://sagebionetworks.jira.com/browse/DPE-1755
- https://sagebionetworks.jira.com/browse/DPE-1764

# **Solution:**
Add tests that test all dags on the following:
- Each dag has at least one task
- Each dag can be imported with no errors (mimics a runtime environment that can match the expected load paths of the dags). This way all commits have these unit tests run against them to catch any import errors (instead of having to go to codespaces or production dag to see them)


# **Testing:**
- Tests run!