### PR TITLE
IT-4153 Use IRSA role for S3 instead of stored AWS connection

### DIFF
--- a/dags/synapse-dataset-to-croissant.py
+++ b/dags/synapse-dataset-to-croissant.py
@@ -88,7 +88,6 @@ dag_params = {
     "delete_out_of_date_from_s3": Param(True, type="boolean"),
     "delete_out_of_date_from_synapse": Param(True, type="boolean"),
     "dataset_collections_for_cleanup": Param(["syn50913342", "syn68939725", "syn71493541", "syn74529385"], type="array"),
-    "aws_conn_id": Param("AWS_SYNAPSE_CROISSANT_METADATA_S3_CONN", type="string"),
 }
 
 dag_config = {
@@ -620,7 +619,7 @@ def execute_push_to_s3(dataset: Entity, dataset_id: str, dataset_version: str, s
             'utf-8')
         metadata_file = BytesIO(croissant_metadata_bytes)
         s3_hook = S3Hook(
-            aws_conn_id=context["params"]["aws_conn_id"], region_name=REGION_NAME, extra_args={
+            aws_conn_id=None, region_name=REGION_NAME, extra_args={
                 "ContentType": "application/ld+json"
             }
         )
@@ -753,7 +752,6 @@ def dataset_to_croissant() -> None:
                             where links back to Synapse entities are connected with the S3
                             object. When this is filled this array is used to filter the
                             S3 objects which will be considered for deletion.
-    - `aws_conn_id`: The connection ID for the AWS connection. Used to authenticate with S3.
     """
 
     @task
@@ -908,7 +906,7 @@ def dataset_to_croissant() -> None:
         """
         with otel_tracer.start_as_current_span("delete_non_current_files_from_s3", context=TraceContextTextMapPropagator().extract(root_carrier_context)) as span:
             s3_hook = S3Hook(
-                aws_conn_id=context["params"]["aws_conn_id"], region_name=REGION_NAME)
+                aws_conn_id=None, region_name=REGION_NAME)
             bucket_objects = s3_hook.list_keys(bucket_name=BUCKET_NAME)
 
             objects_to_delete = extract_s3_objects_to_delete(

--- a/dags/synapse_dataset_to_croissant_minimal.py
+++ b/dags/synapse_dataset_to_croissant_minimal.py
@@ -65,7 +65,6 @@ from src.synapse_hook import SynapseHook
 dag_params = {
     "synapse_conn_id": Param("SYNAPSE_ORCA_SERVICE_ACCOUNT_CONN", type="string"),
     "push_results_to_s3": Param(True, type="boolean"),
-    "aws_conn_id": Param("AWS_SYNAPSE_CROISSANT_METADATA_S3_CONN", type="string"),
     "push_links_to_synapse": Param(True, type="boolean"),
     "delete_out_of_date_from_s3": Param(True, type="boolean"),
     "delete_out_of_date_from_synapse": Param(True, type="boolean"),
@@ -253,7 +252,7 @@ def execute_push_to_s3(dataset: Entity, dataset_id: str, s3_key: str, croissant_
             'utf-8')
         metadata_file = BytesIO(croissant_metadata_bytes)
         s3_hook = S3Hook(
-            aws_conn_id=context["params"]["aws_conn_id"], region_name=REGION_NAME, extra_args={
+            aws_conn_id=None, region_name=REGION_NAME, extra_args={
                 "ContentType": "application/ld+json"
             }
         )
@@ -444,7 +443,7 @@ def save_minimal_jsonld_to_s3() -> None:
         """
         with otel_tracer.start_as_current_span("delete_non_current_files_from_s3", context=TraceContextTextMapPropagator().extract(root_carrier_context)) as span:
             s3_hook = S3Hook(
-                aws_conn_id=context["params"]["aws_conn_id"], region_name=REGION_NAME)
+                aws_conn_id=None, region_name=REGION_NAME)
             bucket_objects = s3_hook.list_keys(bucket_name=BUCKET_NAME)
 
             objects_to_delete = extract_s3_objects_to_delete(


### PR DESCRIPTION
Both croissant DAGs built the `S3Hook` from the `AWS_SYNAPSE_CROISSANT_METADATA_S3_CONN` Airflow connection, which holds a static access key. That connection overrides the IRSA credentials the pod already has.

Setting `aws_conn_id=None` makes `AwsBaseHook` fall back to boto3's default credential chain, which picks up the `AWS_ROLE_ARN` + web-identity token injected via the service-account annotation and assumes the role instead.

- `aws_conn_id=None` at all four `S3Hook` call sites (two files)
- Removed the now-unused `aws_conn_id` DAG param

The stored Airflow connection can be deleted separately once these run green.